### PR TITLE
Timing + Benchmarks + New Sweep Logic

### DIFF
--- a/scripts/plot_bandwidth.py
+++ b/scripts/plot_bandwidth.py
@@ -401,6 +401,9 @@ _PRETTY = {
     "mainmemory": "Main Memory",
     "readonly": "Read-Only",
     "texture": "Texture",
+    # Listed before the plain "l1" entry so a constant grid never matches it.
+    "constantl1.5": "Constant L1.5",
+    "constantl1": "Constant L1",
     "l1": "L1",
     "l2": "L2",
     "l3": "L3",
@@ -420,10 +423,9 @@ def _benchmark_token(name: str) -> str:
 # on both vendors.
 _BLOCK_SWEEP_TOKENS = {"vL1d", "sL1d", "L2", "L3", "Main Memory"}
 
-# Single-block (per-SM) sweeps rendered as one line per thread count. NVIDIA L1
-# plus the NVIDIA read-only and texture cache read-bandwidth benchmarks, which
-# reuse the same 2D (threads x reps) grid layout.
-_SINGLE_LINE_TOKENS = {"L1", "Read-Only", "Texture"}
+# Single-block (per-SM) sweeps: one line per thread count, using the shared
+# 2D (threads x reps) grid for NVIDIA cache read-bandwidth benchmarks.
+_SINGLE_LINE_TOKENS = {"L1", "Read-Only", "Texture", "Constant L1", "Constant L1.5"}
 
 
 def _benchmark_category(name: str) -> tuple[str, str]:

--- a/src/benchmarks/bandwidth/amd_l1ReadBandwidthBlocksweep.cpp
+++ b/src/benchmarks/bandwidth/amd_l1ReadBandwidthBlocksweep.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <algorithm>
 #include <cctype>
+#include <limits>
 
 static constexpr auto WARMUP_REPS = 128;
 
@@ -105,31 +106,58 @@ namespace benchmark
             result.numBlocks = 0;
             result.numReps = 0;
 
+            // Precompute full block/thread/rep axes for CSV alignment.
+            // Sweep runs descending; axes remain ascending for unchanged grid layout.
             for (uint32_t numBlocks = minBlocks; numBlocks <= maxBlocks; numBlocks *= 2)
             {
-                std::vector<std::vector<double>> threadsResults;
-
                 result.blocksTested.push_back(numBlocks);
+            }
+            for (uint32_t numThreads = minThreads; numThreads <= maxThreads; numThreads *= 2)
+            {
+                result.threadsTested.push_back(numThreads);
+            }
+            for (size_t reps = minReps; reps <= maxReps; reps *= 2)
+            {
+                result.repsTested.push_back(reps);
+            }
 
-                for (uint32_t numThreads = minThreads; numThreads <= maxThreads; numThreads *= 2)
+            const size_t numBlockSteps = result.blocksTested.size();
+            const size_t numThreadSteps = result.threadsTested.size();
+            const size_t numRepSteps = result.repsTested.size();
+            // NaN marks configurations skipped by early termination, distinguishing them
+            // from genuine 0 GiB/s measurements.
+            const double UNMEASURED = std::numeric_limits<double>::quiet_NaN();
+
+            result.bandwidth3D.assign(numBlockSteps, std::vector<std::vector<double>>(
+                numThreadSteps, std::vector<double>(numRepSteps, UNMEASURED)));
+
+            // Lowest thread count worth measuring; used as an index into threadsTested.
+            // Once a thread sweep terminates, this and lower counts are skipped for lower blocks.
+            size_t lowestThreadIndex = 0;
+
+            // Search block counts and thread counts from highest to lowest.
+            for (size_t bi = numBlockSteps; bi-- > 0; )
+            {
+                const uint32_t numBlocks = result.blocksTested[bi];
+                double maxBandwidthThisBlock = 0.0;
+
+                for (size_t ti = numThreadSteps; ti-- > lowestThreadIndex; )
                 {
-                    std::vector<double> repsResults;
+                    const uint32_t numThreads = result.threadsTested[ti];
+                    double bestThisThread = 0.0;
 
-                    if (numBlocks == minBlocks)
+                    for (size_t ri = 0; ri < numRepSteps; ++ri)
                     {
-                        result.threadsTested.push_back(numThreads);
-                    }
-
-                    for (size_t reps = minReps; reps <= maxReps; reps *= 2)
-                    {
-                        if (numBlocks == minBlocks && numThreads == minThreads)
-                        {
-                            result.repsTested.push_back(reps);
-                        }
+                        const size_t reps = result.repsTested[ri];
 
                         auto [timeS, bandwidth] = l1ReadBandwidthLauncher(arraySizeBytes, numBlocks, numThreads, reps, stream);
-                        
-                        repsResults.push_back(bandwidth);
+
+                        result.bandwidth3D[bi][ti][ri] = bandwidth;
+
+                        if (bandwidth > bestThisThread)
+                        {
+                            bestThisThread = bandwidth;
+                        }
 
                         if (bandwidth > result.measuredBandwidth)
                         {
@@ -141,10 +169,20 @@ namespace benchmark
                         }
                     }
 
-                    threadsResults.push_back(repsResults);
-                }
+                    // A >=25% drop from the best BW ends this thread sweep
+                    // and skips this and lower thread counts for remaining blocks.
+                    if (maxBandwidthThisBlock > 0.0 &&
+                        bestThisThread <= BANDWIDTH_EARLY_TERMINATION_FACTOR * maxBandwidthThisBlock)
+                    {
+                        lowestThreadIndex = ti + 1;
+                        break;
+                    }
 
-                result.bandwidth3D.push_back(threadsResults);
+                    if (bestThisThread > maxBandwidthThisBlock)
+                    {
+                        maxBandwidthThisBlock = bestThisThread;
+                    }
+                }
             }
 
             util::hipCheck(hipStreamDestroy(stream));

--- a/src/benchmarks/bandwidth/amd_l1WriteBandwidthBlocksweep.cpp
+++ b/src/benchmarks/bandwidth/amd_l1WriteBandwidthBlocksweep.cpp
@@ -6,6 +6,7 @@
 #include <string>
 #include <algorithm>
 #include <cctype>
+#include <limits>
 
 static constexpr auto WARMUP_REPS = 128;
 
@@ -97,31 +98,58 @@ namespace benchmark {
             result.numBlocks = 0;
             result.numReps = 0;
 
+            // Precompute full block/thread/rep axes for CSV alignment.
+            // Sweep runs descending; axes remain ascending for unchanged grid layout.
             for (uint32_t numBlocks = minBlocks; numBlocks <= maxBlocks; numBlocks *= 2)
             {
-                std::vector<std::vector<double>> threadsResults;
-
                 result.blocksTested.push_back(numBlocks);
+            }
+            for (uint32_t numThreads = minThreads; numThreads <= maxThreads; numThreads *= 2)
+            {
+                result.threadsTested.push_back(numThreads);
+            }
+            for (size_t reps = minReps; reps <= maxReps; reps *= 2)
+            {
+                result.repsTested.push_back(reps);
+            }
 
-                for (uint32_t numThreads = minThreads; numThreads <= maxThreads; numThreads *= 2)
+            const size_t numBlockSteps = result.blocksTested.size();
+            const size_t numThreadSteps = result.threadsTested.size();
+            const size_t numRepSteps = result.repsTested.size();
+            // NaN marks configurations skipped by early termination, distinguishing them
+            // from genuine 0 GiB/s measurements.
+            const double UNMEASURED = std::numeric_limits<double>::quiet_NaN();
+
+            result.bandwidth3D.assign(numBlockSteps, std::vector<std::vector<double>>(
+                numThreadSteps, std::vector<double>(numRepSteps, UNMEASURED)));
+
+            // Lowest thread count worth measuring; used as an index into threadsTested.
+            // Once a thread sweep terminates, this and lower counts are skipped for lower blocks.
+            size_t lowestThreadIndex = 0;
+
+            // Search block counts and thread counts from highest to lowest.
+            for (size_t bi = numBlockSteps; bi-- > 0; )
+            {
+                const uint32_t numBlocks = result.blocksTested[bi];
+                double maxBandwidthThisBlock = 0.0;
+
+                for (size_t ti = numThreadSteps; ti-- > lowestThreadIndex; )
                 {
-                    std::vector<double> repsResults;
+                    const uint32_t numThreads = result.threadsTested[ti];
+                    double bestThisThread = 0.0;
 
-                    if (numBlocks == minBlocks)
+                    for (size_t ri = 0; ri < numRepSteps; ++ri)
                     {
-                        result.threadsTested.push_back(numThreads);
-                    }
-
-                    for (size_t reps = minReps; reps <= maxReps; reps *= 2)
-                    {
-                        if (numBlocks == minBlocks && numThreads == minThreads)
-                        {
-                            result.repsTested.push_back(reps);
-                        }
+                        const size_t reps = result.repsTested[ri];
 
                         auto [timeS, bandwidth] = l1WriteBandwidthLauncher(arraySizeBytes, numBlocks, numThreads, reps, stream);
 
-                        repsResults.push_back(bandwidth);
+                        result.bandwidth3D[bi][ti][ri] = bandwidth;
+
+                        if (bandwidth > bestThisThread)
+                        {
+                            bestThisThread = bandwidth;
+                        }
 
                         if (bandwidth > result.measuredBandwidth)
                         {
@@ -133,10 +161,20 @@ namespace benchmark {
                         }
                     }
 
-                    threadsResults.push_back(repsResults);
-                }
+                    // A >=25% drop from the best BW ends this thread sweep
+                    // and skips this and lower thread counts for remaining blocks.
+                    if (maxBandwidthThisBlock > 0.0 &&
+                        bestThisThread <= BANDWIDTH_EARLY_TERMINATION_FACTOR * maxBandwidthThisBlock)
+                    {
+                        lowestThreadIndex = ti + 1;
+                        break;
+                    }
 
-                result.bandwidth3D.push_back(threadsResults);
+                    if (bestThisThread > maxBandwidthThisBlock)
+                    {
+                        maxBandwidthThisBlock = bestThisThread;
+                    }
+                }
             }
 
             util::hipCheck(hipStreamDestroy(stream));

--- a/src/benchmarks/bandwidth/amd_l3ReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/amd_l3ReadBandwidth.cpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <numeric>
 #include <optional>
+#include <limits>
 
 static constexpr auto WARMUP_REPS = 512;
 
@@ -113,31 +114,58 @@ namespace benchmark {
             result.numBlocks = 0;
             result.numReps = 0;
 
+            // Precompute full block/thread/rep axes for CSV alignment.
+            // Sweep runs descending; axes remain ascending for unchanged grid layout.
             for (uint32_t numBlocks = minBlocks; numBlocks <= maxBlocks; numBlocks *= 2)
             {
-                std::vector<std::vector<double>> threadsResults;
-
                 result.blocksTested.push_back(numBlocks);
+            }
+            for (uint32_t numThreads = minThreads; numThreads <= maxThreads; numThreads *= 2)
+            {
+                result.threadsTested.push_back(numThreads);
+            }
+            for (size_t reps = minReps; reps <= maxReps; reps *= 2)
+            {
+                result.repsTested.push_back(reps);
+            }
 
-                for (uint32_t numThreads = minThreads; numThreads <= maxThreads; numThreads *= 2)
+            const size_t numBlockSteps = result.blocksTested.size();
+            const size_t numThreadSteps = result.threadsTested.size();
+            const size_t numRepSteps = result.repsTested.size();
+            // NaN marks configurations skipped by early termination, distinguishing them
+            // from genuine 0 GiB/s measurements.
+            const double UNMEASURED = std::numeric_limits<double>::quiet_NaN();
+
+            result.bandwidth3D.assign(numBlockSteps, std::vector<std::vector<double>>(
+                numThreadSteps, std::vector<double>(numRepSteps, UNMEASURED)));
+
+            // Lowest thread count worth measuring; used as an index into threadsTested.
+            // Once a thread sweep terminates, this and lower counts are skipped for lower blocks.
+            size_t lowestThreadIndex = 0;
+
+            // Search block counts and thread counts from highest to lowest.
+            for (size_t bi = numBlockSteps; bi-- > 0; )
+            {
+                const uint32_t numBlocks = result.blocksTested[bi];
+                double maxBandwidthThisBlock = 0.0;
+
+                for (size_t ti = numThreadSteps; ti-- > lowestThreadIndex; )
                 {
-                    std::vector<double> repsResults;
+                    const uint32_t numThreads = result.threadsTested[ti];
+                    double bestThisThread = 0.0;
 
-                    if (numBlocks == minBlocks)
+                    for (size_t ri = 0; ri < numRepSteps; ++ri)
                     {
-                        result.threadsTested.push_back(numThreads);
-                    }
+                        const size_t reps = result.repsTested[ri];
 
-                    for (size_t reps = minReps; reps <= maxReps; reps *= 2)
-                    {
-                        if (numBlocks == minBlocks && numThreads == minThreads)
-                        {
-                            result.repsTested.push_back(reps);
-                        }
-                        
                         auto [timeS, bandwidth] = l3ReadBandwidthLauncher(arraySizeBytes, numBlocks, numThreads, reps);
-                        
-                        repsResults.push_back(bandwidth);
+
+                        result.bandwidth3D[bi][ti][ri] = bandwidth;
+
+                        if (bandwidth > bestThisThread)
+                        {
+                            bestThisThread = bandwidth;
+                        }
 
                         if (bandwidth > result.measuredBandwidth)
                         {
@@ -149,10 +177,20 @@ namespace benchmark {
                         }
                     }
 
-                    threadsResults.push_back(repsResults);
-                }
+                    // A >=25% drop from the best BW ends this thread sweep
+                    // and skips this and lower thread counts for remaining blocks.
+                    if (maxBandwidthThisBlock > 0.0 &&
+                        bestThisThread <= BANDWIDTH_EARLY_TERMINATION_FACTOR * maxBandwidthThisBlock)
+                    {
+                        lowestThreadIndex = ti + 1;
+                        break;
+                    }
 
-                result.bandwidth3D.push_back(threadsResults);
+                    if (bestThisThread > maxBandwidthThisBlock)
+                    {
+                        maxBandwidthThisBlock = bestThisThread;
+                    }
+                }
             }
             
             return result;

--- a/src/benchmarks/bandwidth/amd_l3WriteBandwidth.cpp
+++ b/src/benchmarks/bandwidth/amd_l3WriteBandwidth.cpp
@@ -5,6 +5,7 @@
 #include <map>
 #include <numeric>
 #include <optional>
+#include <limits>
 
 static constexpr auto WARMUP_REPS = 512;
 
@@ -110,31 +111,58 @@ namespace benchmark {
             result.numBlocks = 0;
             result.numReps = 0;
 
+            // Precompute full block/thread/rep axes for CSV alignment.
+            // Sweep runs descending; axes remain ascending for unchanged grid layout.
             for (uint32_t numBlocks = minBlocks; numBlocks <= maxBlocks; numBlocks *= 2)
             {
-                std::vector<std::vector<double>> threadsResults;
-
                 result.blocksTested.push_back(numBlocks);
+            }
+            for (uint32_t numThreads = minThreads; numThreads <= maxThreads; numThreads *= 2)
+            {
+                result.threadsTested.push_back(numThreads);
+            }
+            for (size_t reps = minReps; reps <= maxReps; reps *= 2)
+            {
+                result.repsTested.push_back(reps);
+            }
 
-                for (uint32_t numThreads = minThreads; numThreads <= maxThreads; numThreads *= 2)
+            const size_t numBlockSteps = result.blocksTested.size();
+            const size_t numThreadSteps = result.threadsTested.size();
+            const size_t numRepSteps = result.repsTested.size();
+            // NaN marks configurations skipped by early termination, distinguishing them
+            // from genuine 0 GiB/s measurements.
+            const double UNMEASURED = std::numeric_limits<double>::quiet_NaN();
+
+            result.bandwidth3D.assign(numBlockSteps, std::vector<std::vector<double>>(
+                numThreadSteps, std::vector<double>(numRepSteps, UNMEASURED)));
+
+            // Lowest thread count worth measuring; used as an index into threadsTested.
+            // Once a thread sweep terminates, this and lower counts are skipped for lower blocks.
+            size_t lowestThreadIndex = 0;
+
+            // Search block counts and thread counts from highest to lowest.
+            for (size_t bi = numBlockSteps; bi-- > 0; )
+            {
+                const uint32_t numBlocks = result.blocksTested[bi];
+                double maxBandwidthThisBlock = 0.0;
+
+                for (size_t ti = numThreadSteps; ti-- > lowestThreadIndex; )
                 {
-                    std::vector<double> repsResults;
+                    const uint32_t numThreads = result.threadsTested[ti];
+                    double bestThisThread = 0.0;
 
-                    if (numBlocks == minBlocks)
+                    for (size_t ri = 0; ri < numRepSteps; ++ri)
                     {
-                        result.threadsTested.push_back(numThreads);
-                    }
+                        const size_t reps = result.repsTested[ri];
 
-                    for (size_t reps = minReps; reps <= maxReps; reps *= 2)
-                    {
-                        if (numBlocks == minBlocks && numThreads == minThreads)
-                        {
-                            result.repsTested.push_back(reps);
-                        }
-                        
                         auto [timeS, bandwidth] = l3WriteBandwidthLauncher(arraySizeBytes, numBlocks, numThreads, reps);
-                        
-                        repsResults.push_back(bandwidth);
+
+                        result.bandwidth3D[bi][ti][ri] = bandwidth;
+
+                        if (bandwidth > bestThisThread)
+                        {
+                            bestThisThread = bandwidth;
+                        }
 
                         if (bandwidth > result.measuredBandwidth)
                         {
@@ -146,10 +174,20 @@ namespace benchmark {
                         }
                     }
 
-                    threadsResults.push_back(repsResults);
-                }
+                    // A >=25% drop from the best BW ends this thread sweep
+                    // and skips this and lower thread counts for remaining blocks.
+                    if (maxBandwidthThisBlock > 0.0 &&
+                        bestThisThread <= BANDWIDTH_EARLY_TERMINATION_FACTOR * maxBandwidthThisBlock)
+                    {
+                        lowestThreadIndex = ti + 1;
+                        break;
+                    }
 
-                result.bandwidth3D.push_back(threadsResults);
+                    if (bestThisThread > maxBandwidthThisBlock)
+                    {
+                        maxBandwidthThisBlock = bestThisThread;
+                    }
+                }
             }
 
             return result;

--- a/src/benchmarks/bandwidth/l2ReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/l2ReadBandwidth.cpp
@@ -138,8 +138,12 @@ namespace benchmark {
         result.numBlocks = 0;
         result.numReps = 0;
 
-        // Precompute the full thread/rep axes for CSV alignment. Every block indexes
-        // into these axes, even if early stopping skips some thread counts.
+        // Precompute full block/thread/rep axes for CSV alignment.
+        // Sweep runs descending; axes remain ascending for unchanged grid layout.
+        for (uint32_t numBlocks = minBlocks; numBlocks <= maxBlocks; numBlocks *= 2)
+        {
+            result.blocksTested.push_back(numBlocks);
+        }
         for (uint32_t numThreads = minThreads; numThreads <= maxThreads; numThreads *= 2)
         {
             result.threadsTested.push_back(numThreads);
@@ -149,24 +153,27 @@ namespace benchmark {
             result.repsTested.push_back(reps);
         }
 
+        const size_t numBlockSteps = result.blocksTested.size();
         const size_t numThreadSteps = result.threadsTested.size();
         const size_t numRepSteps = result.repsTested.size();
-        // NaN marks configurations skipped by early stopping, distinguishing them from
+        // NaN marks configurations skipped by early termination, distinguishing them from
         // genuine 0 GiB/s measurements.
         const double UNMEASURED = std::numeric_limits<double>::quiet_NaN();
 
-        for (uint32_t numBlocks = minBlocks; numBlocks <= maxBlocks; numBlocks *= 2)
+        result.bandwidth3D.assign(numBlockSteps, std::vector<std::vector<double>>(
+            numThreadSteps, std::vector<double>(numRepSteps, UNMEASURED)));
+
+        // Lowest thread count worth measuring; used as an index into threadsTested.
+        // Once a thread sweep terminates, this and lower counts are skipped for lower blocks.
+        size_t lowestThreadIndex = 0;
+
+        // Search block counts and thread counts from highest to lowest.
+        for (size_t bi = numBlockSteps; bi-- > 0; )
         {
-            result.blocksTested.push_back(numBlocks);
+            const uint32_t numBlocks = result.blocksTested[bi];
+            double maxBandwidthThisBlock = 0.0;
 
-            std::vector<std::vector<double>> threadsResults(
-                numThreadSteps, std::vector<double>(numRepSteps, UNMEASURED));
-
-            // Early-stopping thread search: Search thread counts from highest to lowest.
-            // Once the best bandwidth for a thread count drops below the previous (higher) one,
-            // stop: lower thread counts are assumed to be past the peak and are not measured.
-            double prevBandwidth = -1.0;
-            for (size_t ti = numThreadSteps; ti-- > 0; )
+            for (size_t ti = numThreadSteps; ti-- > lowestThreadIndex; )
             {
                 const uint32_t numThreads = result.threadsTested[ti];
                 double bestThisThread = 0.0;
@@ -177,7 +184,7 @@ namespace benchmark {
 
                     auto [timeS, bandwidth] = l2ReadBandwidthLauncher(arraySizeBytes, numBlocks, numThreads, reps);
 
-                    threadsResults[ti][ri] = bandwidth;
+                    result.bandwidth3D[bi][ti][ri] = bandwidth;
                     bestThisThread = std::max(bestThisThread, bandwidth);
 
                     if (bandwidth > result.measuredBandwidth)
@@ -190,14 +197,17 @@ namespace benchmark {
                     }
                 }
 
-                if (prevBandwidth >= 0.0 && bestThisThread < prevBandwidth)
+                // A >=25% drop from the best BW ends this thread sweep
+                // and skips this and lower thread counts for remaining blocks.
+                if (maxBandwidthThisBlock > 0.0 &&
+                    bestThisThread <= BANDWIDTH_EARLY_TERMINATION_FACTOR * maxBandwidthThisBlock)
                 {
-                    break; // bandwidth dropped -> previous thread count was the peak
+                    lowestThreadIndex = ti + 1;
+                    break;
                 }
-                prevBandwidth = bestThisThread;
-            }
 
-            result.bandwidth3D.push_back(threadsResults);
+                maxBandwidthThisBlock = std::max(maxBandwidthThisBlock, bestThisThread);
+            }
         }
 
         return result;

--- a/src/benchmarks/bandwidth/l2WriteBandwidth.cpp
+++ b/src/benchmarks/bandwidth/l2WriteBandwidth.cpp
@@ -124,8 +124,12 @@ namespace benchmark {
         result.numBlocks = 0;
         result.numReps = 0;
 
-        // Precompute the full thread/rep axes for CSV alignment. Every block indexes
-        // into these axes, even if early stopping skips some thread counts.
+        // Precompute full block/thread/rep axes for CSV alignment.
+        // Sweep runs descending; axes remain ascending for unchanged grid layout.
+        for (uint32_t numBlocks = minBlocks; numBlocks <= maxBlocks; numBlocks *= 2)
+        {
+            result.blocksTested.push_back(numBlocks);
+        }
         for (uint32_t numThreads = minThreads; numThreads <= maxThreads; numThreads *= 2)
         {
             result.threadsTested.push_back(numThreads);
@@ -135,24 +139,27 @@ namespace benchmark {
             result.repsTested.push_back(reps);
         }
 
+        const size_t numBlockSteps = result.blocksTested.size();
         const size_t numThreadSteps = result.threadsTested.size();
         const size_t numRepSteps = result.repsTested.size();
-        // NaN marks configurations skipped by early stopping, distinguishing them from
+        // NaN marks configurations skipped by early termination, distinguishing them from
         // genuine 0 GiB/s measurements.
         const double UNMEASURED = std::numeric_limits<double>::quiet_NaN();
 
-        for (uint32_t numBlocks = minBlocks; numBlocks <= maxBlocks; numBlocks *= 2)
+        result.bandwidth3D.assign(numBlockSteps, std::vector<std::vector<double>>(
+            numThreadSteps, std::vector<double>(numRepSteps, UNMEASURED)));
+
+        // Lowest thread count worth measuring; used as an index into threadsTested.
+        // Once a thread sweep terminates, this and lower counts are skipped for lower blocks.
+        size_t lowestThreadIndex = 0;
+
+        // Search block counts and thread counts from highest to lowest.
+        for (size_t bi = numBlockSteps; bi-- > 0; )
         {
-            result.blocksTested.push_back(numBlocks);
+            const uint32_t numBlocks = result.blocksTested[bi];
+            double maxBandwidthThisBlock = 0.0;
 
-            std::vector<std::vector<double>> threadsResults(
-                numThreadSteps, std::vector<double>(numRepSteps, UNMEASURED));
-
-            // Early-stopping thread search: Search thread counts from highest to lowest.
-            // Once the best bandwidth for a thread count drops below the previous (higher) one,
-            // stop: lower thread counts are assumed to be past the peak and are not measured.
-            double prevBandwidth = -1.0;
-            for (size_t ti = numThreadSteps; ti-- > 0; )
+            for (size_t ti = numThreadSteps; ti-- > lowestThreadIndex; )
             {
                 const uint32_t numThreads = result.threadsTested[ti];
                 double bestThisThread = 0.0;
@@ -163,7 +170,7 @@ namespace benchmark {
 
                     auto [timeS, bandwidth] = l2WriteBandwidthLauncher(arraySizeBytes, numBlocks, numThreads, reps);
 
-                    threadsResults[ti][ri] = bandwidth;
+                    result.bandwidth3D[bi][ti][ri] = bandwidth;
                     bestThisThread = std::max(bestThisThread, bandwidth);
 
                     if (bandwidth > result.measuredBandwidth)
@@ -176,14 +183,17 @@ namespace benchmark {
                     }
                 }
 
-                if (prevBandwidth >= 0.0 && bestThisThread < prevBandwidth)
+                // A >=25% drop from the best BW ends this thread sweep
+                // and skips this and lower thread counts for remaining blocks.
+                if (maxBandwidthThisBlock > 0.0 &&
+                    bestThisThread <= BANDWIDTH_EARLY_TERMINATION_FACTOR * maxBandwidthThisBlock)
                 {
-                    break; // bandwidth dropped -> previous thread count was the peak
+                    lowestThreadIndex = ti + 1;
+                    break;
                 }
-                prevBandwidth = bestThisThread;
-            }
 
-            result.bandwidth3D.push_back(threadsResults);
+                maxBandwidthThisBlock = std::max(maxBandwidthThisBlock, bestThisThread);
+            }
         }
 
         return result;

--- a/src/benchmarks/bandwidth/mainMemoryReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/mainMemoryReadBandwidth.cpp
@@ -6,6 +6,7 @@
 #include <numeric>
 #include <optional>
 #include <tuple>
+#include <limits>
 
 static constexpr auto SIZE_DOWN = DEFAULT_SIZE_DOWN_FACTOR;// Factor
 static constexpr auto MS_PER_SECOND = 1000.0;// ms
@@ -179,29 +180,44 @@ namespace benchmark {
         result.numBlocks = 0;
         result.numReps = 0;
 
+        // Precompute full block/thread/rep axes for CSV alignment.
+        // Sweep runs descending; axes remain ascending for unchanged grid layout.
         for (uint32_t numBlocks = minBlocks; numBlocks <= maxBlocks; numBlocks *= 2)
         {
-            std::vector<std::vector<double>> threadsResults;
-
             result.blocksTested.push_back(numBlocks);
+        }
+        for (uint32_t numThreads = minThreads; numThreads <= maxThreads; numThreads *= 2)
+        {
+            result.threadsTested.push_back(numThreads);
+        }
+        result.repsTested.push_back(1); // single streaming pass (see note above)
 
-            for (uint32_t numThreads = minThreads; numThreads <= maxThreads; numThreads *= 2)
+        const size_t numBlockSteps = result.blocksTested.size();
+        const size_t numThreadSteps = result.threadsTested.size();
+        // NaN marks configurations skipped by early termination, distinguishing them from
+        // genuine 0 GiB/s measurements.
+        const double UNMEASURED = std::numeric_limits<double>::quiet_NaN();
+
+        result.bandwidth3D.assign(numBlockSteps, std::vector<std::vector<double>>(
+            numThreadSteps, std::vector<double>(1, UNMEASURED)));
+
+        // Lowest thread count worth measuring; used as an index into threadsTested.
+        // Once a thread sweep terminates, this and lower counts are skipped for lower blocks.
+        size_t lowestThreadIndex = 0;
+
+        // Search block counts and thread counts from highest to lowest.
+        for (size_t bi = numBlockSteps; bi-- > 0; )
+        {
+            const uint32_t numBlocks = result.blocksTested[bi];
+            double maxBandwidthThisBlock = 0.0;
+
+            for (size_t ti = numThreadSteps; ti-- > lowestThreadIndex; )
             {
-                std::vector<double> repsResults;
-
-                if (numBlocks == minBlocks)
-                {
-                    result.threadsTested.push_back(numThreads);
-                }
-
-                if (numBlocks == minBlocks && numThreads == minThreads)
-                {
-                    result.repsTested.push_back(1); // single streaming pass (see note above)
-                }
+                const uint32_t numThreads = result.threadsTested[ti];
 
                 auto [timeS, bandwidth] = mainMemoryReadBandwidthSweepLauncher(arraySizeBytes, numBlocks, numThreads, 1);
 
-                repsResults.push_back(bandwidth);
+                result.bandwidth3D[bi][ti][0] = bandwidth;
 
                 if (bandwidth > result.measuredBandwidth)
                 {
@@ -212,10 +228,20 @@ namespace benchmark {
                     result.numReps = 1;
                 }
 
-                threadsResults.push_back(repsResults);
-            }
+                // A >=25% drop from the best BW ends this thread sweep
+                // and skips this and lower thread counts for remaining blocks.
+                if (maxBandwidthThisBlock > 0.0 &&
+                    bandwidth <= BANDWIDTH_EARLY_TERMINATION_FACTOR * maxBandwidthThisBlock)
+                {
+                    lowestThreadIndex = ti + 1;
+                    break;
+                }
 
-            result.bandwidth3D.push_back(threadsResults);
+                if (bandwidth > maxBandwidthThisBlock)
+                {
+                    maxBandwidthThisBlock = bandwidth;
+                }
+            }
         }
 
         return result;

--- a/src/benchmarks/bandwidth/mainMemoryWriteBandwidth.cpp
+++ b/src/benchmarks/bandwidth/mainMemoryWriteBandwidth.cpp
@@ -6,6 +6,7 @@
 #include <numeric>
 #include <optional>
 #include <tuple>
+#include <limits>
 
 static constexpr auto SIZE_DOWN = DEFAULT_SIZE_DOWN_FACTOR;// Factor
 static constexpr auto MS_PER_SECOND = 1000.0;// ms
@@ -164,29 +165,44 @@ namespace benchmark {
         result.numBlocks = 0;
         result.numReps = 0;
 
+        // Precompute full block/thread/rep axes for CSV alignment.
+        // Sweep runs descending; axes remain ascending for unchanged grid layout.
         for (uint32_t numBlocks = minBlocks; numBlocks <= maxBlocks; numBlocks *= 2)
         {
-            std::vector<std::vector<double>> threadsResults;
-
             result.blocksTested.push_back(numBlocks);
+        }
+        for (uint32_t numThreads = minThreads; numThreads <= maxThreads; numThreads *= 2)
+        {
+            result.threadsTested.push_back(numThreads);
+        }
+        result.repsTested.push_back(1); // single streaming pass (see note above)
 
-            for (uint32_t numThreads = minThreads; numThreads <= maxThreads; numThreads *= 2)
+        const size_t numBlockSteps = result.blocksTested.size();
+        const size_t numThreadSteps = result.threadsTested.size();
+        // NaN marks configurations skipped by early termination, distinguishing them from
+        // genuine 0 GiB/s measurements.
+        const double UNMEASURED = std::numeric_limits<double>::quiet_NaN();
+
+        result.bandwidth3D.assign(numBlockSteps, std::vector<std::vector<double>>(
+            numThreadSteps, std::vector<double>(1, UNMEASURED)));
+
+        // Lowest thread count worth measuring; used as an index into threadsTested.
+        // Once a thread sweep terminates, this and lower counts are skipped for lower blocks.
+        size_t lowestThreadIndex = 0;
+
+        // Search block counts and thread counts from highest to lowest.
+        for (size_t bi = numBlockSteps; bi-- > 0; )
+        {
+            const uint32_t numBlocks = result.blocksTested[bi];
+            double maxBandwidthThisBlock = 0.0;
+
+            for (size_t ti = numThreadSteps; ti-- > lowestThreadIndex; )
             {
-                std::vector<double> repsResults;
-
-                if (numBlocks == minBlocks)
-                {
-                    result.threadsTested.push_back(numThreads);
-                }
-
-                if (numBlocks == minBlocks && numThreads == minThreads)
-                {
-                    result.repsTested.push_back(1); // single streaming pass (see note above)
-                }
+                const uint32_t numThreads = result.threadsTested[ti];
 
                 auto [timeS, bandwidth] = mainMemoryWriteBandwidthSweepLauncher(arraySizeBytes, numBlocks, numThreads, 1);
 
-                repsResults.push_back(bandwidth);
+                result.bandwidth3D[bi][ti][0] = bandwidth;
 
                 if (bandwidth > result.measuredBandwidth)
                 {
@@ -197,10 +213,20 @@ namespace benchmark {
                     result.numReps = 1;
                 }
 
-                threadsResults.push_back(repsResults);
-            }
+                // A >=25% drop from the best BW ends this thread sweep
+                // and skips this and lower thread counts for remaining blocks.
+                if (maxBandwidthThisBlock > 0.0 &&
+                    bandwidth <= BANDWIDTH_EARLY_TERMINATION_FACTOR * maxBandwidthThisBlock)
+                {
+                    lowestThreadIndex = ti + 1;
+                    break;
+                }
 
-            result.bandwidth3D.push_back(threadsResults);
+                if (bandwidth > maxBandwidthThisBlock)
+                {
+                    maxBandwidthThisBlock = bandwidth;
+                }
+            }
         }
 
         return result;

--- a/src/benchmarks/bandwidth/nvidia_constantL15ReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/nvidia_constantL15ReadBandwidth.cpp
@@ -1,0 +1,271 @@
+#include "benchmarks/benchmark.hpp"
+#include "utils/util.hpp"
+#include "const/constArray16384.hpp"
+
+#include <vector>
+#include <cstdlib>
+#include <string>
+#include <algorithm>
+
+static constexpr auto WARMUP_REPS = 8;
+
+
+static constexpr auto ROUNDS = DEFAULT_ROUNDS;// rounds
+
+static constexpr size_t MIN_EXPECTED_SIZE = 8192;// 8 * KiB, same assumption the Constant L1.5 Size benchmark makes
+static constexpr auto MAX_ALLOWED_SIZE = MAX_ALLOWED_INDEX * sizeof(uint32_t);// 63 KiB of the 64 KiB constant array
+
+// Minimum stride that places each load on a different constant cache line.
+// Current NVIDIA constant cache lines are 64B; larger strides show no further change.
+static constexpr size_t MIN_LINE_SKIP_STRIDE = 64;
+
+// Constant L1.5 bandwidth benchmark for a single SM. Uses ld.const on the
+// **constant** array, with each thread striding by one fetch granularity so
+// every load targets a fresh cache line. This avoids the L1/L1.5 mixture caused
+// by contiguous loads. The access pattern matches the Constant L1.5 Size and
+// Latency benchmarks; per-access eviction is avoided because it would serialize
+// the loop and measure eviction cost rather than streaming bandwidth.
+__global__ void constantL15ReadBandwidthKernel(uint32_t* __restrict__ dst, uint64_t* __restrict__ timing_result, size_t elementsPerThread, size_t reps, size_t strideElements)
+{
+    const uint32_t tid = threadIdx.x;
+    const uint32_t* base = arr16384AscStride0 + tid * elementsPerThread * strideElements;
+
+    uint32_t dummy = 0;
+
+    // Warm up the constant caches
+    for (size_t rep = 0; rep < WARMUP_REPS; ++rep)
+    {
+        for (size_t i = 0; i < elementsPerThread; ++i)
+        {
+            uint32_t loaded = 0;
+
+            #ifdef __HIP_PLATFORM_NVIDIA__
+            asm volatile (
+                "{\n\t"
+                ".reg .u64 cp;\n\t"
+                "cvta.to.const.u64 cp, %1;\n\t"
+                "ld.const.u32 %0, [cp];\n\t"
+                "}"
+                : "=r"(loaded)
+                : "l"(base + i * strideElements)
+                : "memory"
+            );
+            #endif
+
+            dummy ^= loaded;
+        }
+    }
+
+    uint64_t start = 0, end = 0;
+
+    __syncthreads();
+
+    if (tid == 0)
+    {
+        #ifdef __HIP_PLATFORM_NVIDIA__
+        __asm__ volatile (
+            "mov.u64 %0, %%clock64;\n\t"
+            : "=l"(start)
+            :
+            : "memory"
+        );
+        #endif
+    }
+
+    __syncthreads();
+
+    for (size_t rep = 0; rep < reps; ++rep)
+    {
+        for (size_t i = 0; i < elementsPerThread; ++i)
+        {
+            uint32_t loaded = 0;
+
+            #ifdef __HIP_PLATFORM_NVIDIA__
+            __asm__ volatile (
+                "{\n\t"
+                ".reg .u64 cp;\n\t"
+                "cvta.to.const.u64 cp, %1;\n\t"
+                "ld.const.u32 %0, [cp];\n\t"
+                "}"
+                : "=r"(loaded)
+                : "l"(base + i * strideElements)
+                : "memory"
+            );
+            #endif
+
+            dummy ^= loaded;
+        }
+    }
+
+    __syncthreads();
+
+    if (tid == 0)
+    {
+        #ifdef __HIP_PLATFORM_NVIDIA__
+        __asm__ volatile (
+            "mov.u64 %0, %%clock64;\n\t"
+            : "=l"(end)
+            :
+            : "memory"
+        );
+        #endif
+
+        *timing_result = end - start;
+    }
+
+    dst[tid] = dummy; // prevent dead code elimination
+}
+
+
+static std::tuple<uint64_t, double, double> constantL15ReadBandwidthLauncher(size_t arraySizeBytes, uint32_t numThreads, size_t reps, size_t strideBytes)
+{
+    size_t strideElements = strideBytes / sizeof(uint32_t);
+    size_t totalElements = arraySizeBytes / sizeof(uint32_t);
+    // One load per stride, so the working set spans elementsPerThread * stride
+    // elements per thread while only elementsPerThread of them are read.
+    size_t elementsPerThread = totalElements / numThreads / strideElements;
+
+    uint32_t *d_dstArr = util::allocateGPUMemory<uint32_t>(numThreads);
+    uint64_t *d_timingResult = util::allocateGPUMemory<uint64_t>(1);
+
+    // Run the kernel
+    constantL15ReadBandwidthKernel<<<1, numThreads>>>(d_dstArr, d_timingResult, elementsPerThread, reps, strideElements);
+
+    // Get the timings from the device
+    std::vector<uint64_t> timingResult = util::copyFromDevice<uint64_t>(d_timingResult, 1);
+
+    util::hipCheck(hipFree(d_dstArr));
+    util::hipCheck(hipFree(d_timingResult));
+
+    // Constant working sets are small, so integer division can leave bytes untouched.
+    // Count only the bytes actually read, not the full cache lines fetched by the stride.
+    double gpuClockHz = util::getDeviceProperties().clockRate * 1000;
+    double dataGiB = (double) (elementsPerThread * numThreads * sizeof(uint32_t)) * reps / (1 * GiB);
+    double timeS = (double) timingResult[0] / gpuClockHz;
+
+    // return (cycles, time in seconds, measured bandwidth)
+    return {timingResult[0], timeS, dataGiB / timeS};
+}
+
+
+// Constant memory is limited to 64 KiB, so cap the requested size.
+// Keep the working set above MIN_EXPECTED_SIZE to avoid fitting in constant L1.
+static size_t capConstantArraySize(size_t arraySizeBytes)
+{
+    if (arraySizeBytes > MAX_ALLOWED_SIZE) {
+        std::cerr << "WARNING: Constant L1.5 Read Bandwidth requested " << arraySizeBytes
+                  << " Bytes of constant data, capping to " << MAX_ALLOWED_SIZE << " Bytes" << std::endl;
+        arraySizeBytes = MAX_ALLOWED_SIZE;
+    }
+    if (arraySizeBytes < MIN_EXPECTED_SIZE) {
+        std::cerr << "WARNING: Constant L1.5 Read Bandwidth working set of " << arraySizeBytes
+                  << " Bytes may still fit into the constant L1, results may reflect the L1 instead" << std::endl;
+    }
+
+    return arraySizeBytes;
+}
+
+// Use at least one full constant cache line per stride to avoid L1 reuse and isolate L1.5 traffic.
+static size_t capStride(size_t strideBytes)
+{
+    strideBytes = std::max(strideBytes, MIN_LINE_SKIP_STRIDE);
+
+    return strideBytes - (strideBytes % sizeof(uint32_t));
+}
+
+// Bound threads by the number of distinct cache lines available.
+// Each thread gets totalElements / strideElements lines.
+static uint32_t capNumThreads(size_t arraySizeBytes, size_t strideBytes)
+{
+    size_t lines = (arraySizeBytes / sizeof(uint32_t)) / (strideBytes / sizeof(uint32_t));
+    uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+
+    return static_cast<uint32_t>(std::min(static_cast<size_t>(maxNumThreads), lines));
+}
+
+
+namespace benchmark
+{
+    namespace nvidia
+    {
+        double measureConstantL15ReadBandwidth(size_t arraySizeBytes, size_t constantFetchGranularityBytes)
+        {
+            arraySizeBytes = capConstantArraySize(arraySizeBytes);
+            size_t strideBytes = capStride(constantFetchGranularityBytes);
+
+            uint32_t maxNumThreads = capNumThreads(arraySizeBytes, strideBytes);
+            size_t maxReps = MAX_REPS;
+
+            if (maxNumThreads == 0) {
+                std::cerr << "WARNING: Constant L1.5 Read Bandwidth working set too small to benchmark, skipping" << std::endl;
+                return 0.0;
+            }
+
+            std::vector<double> results(ROUNDS);
+
+            for (uint32_t i = 0; i < ROUNDS; ++i)
+            {
+                results[i] = std::get<2>(constantL15ReadBandwidthLauncher(arraySizeBytes, maxNumThreads, maxReps, strideBytes));
+            }
+
+            return util::average(results);
+        }
+
+        CacheBandwidthResult measureConstantL15ReadBandwidthSweep(size_t arraySizeBytes, size_t constantFetchGranularityBytes)
+        {
+            arraySizeBytes = capConstantArraySize(arraySizeBytes);
+            size_t strideBytes = capStride(constantFetchGranularityBytes);
+
+            uint32_t minNumThreads = util::getDeviceProperties().warpSize;
+            uint32_t maxNumThreads = capNumThreads(arraySizeBytes, strideBytes);
+            size_t minReps = MIN_REPS;
+            size_t maxReps = MAX_REPS;
+
+            CacheBandwidthResult result{};
+            result.measuredBandwidth = 0.0;
+            result.dataBytes = arraySizeBytes;
+            result.cycles = 0;
+            result.time = 0.0;
+            result.numThreads = 0;
+            result.numBlocks = 1;
+            result.numReps = 0;
+
+            if (maxNumThreads < minNumThreads) {
+                std::cerr << "WARNING: Constant L1.5 Read Bandwidth working set too small for a full warp, skipping" << std::endl;
+                return result;
+            }
+
+            for (uint32_t numThreads = minNumThreads; numThreads <= maxNumThreads; numThreads *= 2)
+            {
+                std::vector<double> bandwidthResults;
+
+                result.threadsTested.push_back(numThreads);
+
+                for (size_t reps = minReps; reps <= maxReps; reps *= 2)
+                {
+                    if (numThreads == minNumThreads)
+                    {
+                        result.repsTested.push_back(reps);
+                    }
+
+                    auto [cycles, timeS, bandwidth] = constantL15ReadBandwidthLauncher(arraySizeBytes, numThreads, reps, strideBytes);
+
+                    bandwidthResults.push_back(bandwidth);
+
+                    if (bandwidth > result.measuredBandwidth)
+                    {
+                        result.measuredBandwidth = bandwidth;
+                        result.cycles = cycles;
+                        result.time = timeS;
+                        result.numThreads = numThreads;
+                        result.numReps = reps;
+                    }
+                }
+
+                result.bandwidthGridGiBs.push_back(bandwidthResults);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/benchmarks/bandwidth/nvidia_constantL15ReadBandwidth.hpp
+++ b/src/benchmarks/bandwidth/nvidia_constantL15ReadBandwidth.hpp
@@ -1,0 +1,37 @@
+#pragma once
+
+#include <cstddef>
+
+#include "typedef/cacheBandwidthResult.hpp"
+
+namespace benchmark {
+    namespace nvidia {
+        /**
+         * @brief Measure achievable constant L1.5 cache read bandwidth of a single
+         *        MultiProcessor.
+         *
+         * @param arraySizeBytes Size of the constant array region in bytes used for the test.
+         *                       Must exceed the constant L1 so the timed loop is served by
+         *                       the L1.5 instead.
+         * @param constantFetchGranularityBytes Stride between loads. Skips a full constant
+         *                       cache line per access so no load can hit a line the constant
+         *                       L1 already holds; clamped up to a line if smaller.
+         * @return Bandwidth in GiB/s.
+         */
+        double measureConstantL15ReadBandwidth(size_t arraySizeBytes, size_t constantFetchGranularityBytes);
+
+        /**
+         * @brief Measure constant L1.5 cache read bandwidth of a single MultiProcessor
+         *        with optimal number search for threads and reps.
+         *
+         * @param arraySizeBytes Size of the constant array region in bytes used for the test.
+         *                       Must exceed the constant L1 so the timed loop is served by
+         *                       the L1.5 instead.
+         * @param constantFetchGranularityBytes Stride between loads. Skips a full constant
+         *                       cache line per access so no load can hit a line the constant
+         *                       L1 already holds; clamped up to a line if smaller.
+         * @return Bandwidth in GiB/s and the optimal configuration.
+         */
+        CacheBandwidthResult measureConstantL15ReadBandwidthSweep(size_t arraySizeBytes, size_t constantFetchGranularityBytes);
+    }
+}

--- a/src/benchmarks/bandwidth/nvidia_constantL1ReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/nvidia_constantL1ReadBandwidth.cpp
@@ -1,0 +1,244 @@
+#include "benchmarks/benchmark.hpp"
+#include "utils/util.hpp"
+#include "const/constArray16384.hpp"
+
+#include <vector>
+#include <cstdlib>
+#include <string>
+#include <algorithm>
+
+static constexpr auto WARMUP_REPS = 8;
+
+
+static constexpr auto ROUNDS = DEFAULT_ROUNDS;// rounds
+
+static constexpr auto MAX_ALLOWED_SIZE = MAX_ALLOWED_INDEX * sizeof(uint32_t);// 63 KiB of the 64 KiB constant array
+
+// Constant L1 bandwidth benchmark for a single SM. Uses ld.const on the shared
+// constant array; the caller provides a working set that fits in constant L1.
+// Scalar loads are used because the uint32_t array has no guaranteed 16-byte alignment.
+__global__ void constantL1ReadBandwidthKernel(uint32_t* __restrict__ dst, uint64_t* __restrict__ timing_result, size_t elementsPerThread, size_t reps)
+{
+    const uint32_t tid = threadIdx.x;
+    const uint32_t* base = arr16384AscStride0 + tid * elementsPerThread;
+
+    uint32_t dummy = 0;
+
+    // Warm up the constant cache
+    for (size_t rep = 0; rep < WARMUP_REPS; ++rep)
+    {
+        for (size_t i = 0; i < elementsPerThread; ++i)
+        {
+            uint32_t loaded = 0;
+
+            #ifdef __HIP_PLATFORM_NVIDIA__
+            asm volatile (
+                "{\n\t"
+                ".reg .u64 cp;\n\t"
+                "cvta.to.const.u64 cp, %1;\n\t"
+                "ld.const.u32 %0, [cp];\n\t"
+                "}"
+                : "=r"(loaded)
+                : "l"(base + i)
+                : "memory"
+            );
+            #endif
+
+            dummy ^= loaded;
+        }
+    }
+
+    uint64_t start = 0, end = 0;
+
+    __syncthreads();
+
+    if (tid == 0)
+    {
+        #ifdef __HIP_PLATFORM_NVIDIA__
+        __asm__ volatile (
+            "mov.u64 %0, %%clock64;\n\t"
+            : "=l"(start)
+            :
+            : "memory"
+        );
+        #endif
+    }
+
+    __syncthreads();
+
+    for (size_t rep = 0; rep < reps; ++rep)
+    {
+        for (size_t i = 0; i < elementsPerThread; ++i)
+        {
+            uint32_t loaded = 0;
+
+            #ifdef __HIP_PLATFORM_NVIDIA__
+            __asm__ volatile (
+                "{\n\t"
+                ".reg .u64 cp;\n\t"
+                "cvta.to.const.u64 cp, %1;\n\t"
+                "ld.const.u32 %0, [cp];\n\t"
+                "}"
+                : "=r"(loaded)
+                : "l"(base + i)
+                : "memory"
+            );
+            #endif
+
+            dummy ^= loaded;
+        }
+    }
+
+    __syncthreads();
+
+    if (tid == 0)
+    {
+        #ifdef __HIP_PLATFORM_NVIDIA__
+        __asm__ volatile (
+            "mov.u64 %0, %%clock64;\n\t"
+            : "=l"(end)
+            :
+            : "memory"
+        );
+        #endif
+
+        *timing_result = end - start;
+    }
+
+    dst[tid] = dummy; // prevent dead code elimination
+}
+
+
+static std::tuple<uint64_t, double, double> constantL1ReadBandwidthLauncher(size_t arraySizeBytes, uint32_t numThreads, size_t reps)
+{
+    size_t totalElements = arraySizeBytes / sizeof(uint32_t);
+    size_t elementsPerThread = totalElements / numThreads;
+
+    uint32_t *d_dstArr = util::allocateGPUMemory<uint32_t>(numThreads);
+    uint64_t *d_timingResult = util::allocateGPUMemory<uint64_t>(1);
+
+    // Run the kernel
+    constantL1ReadBandwidthKernel<<<1, numThreads>>>(d_dstArr, d_timingResult, elementsPerThread, reps);
+
+    // Get the timings from the device
+    std::vector<uint64_t> timingResult = util::copyFromDevice<uint64_t>(d_timingResult, 1);
+
+    util::hipCheck(hipFree(d_dstArr));
+    util::hipCheck(hipFree(d_timingResult));
+
+    // Constant working sets are small, so integer division can leave bytes untouched.
+    // Use the bytes actually read rather than the requested array size.
+    double gpuClockHz = util::getDeviceProperties().clockRate * 1000;
+    double dataGiB = (double) (elementsPerThread * numThreads * sizeof(uint32_t)) * reps / (1 * GiB);
+    double timeS = (double) timingResult[0] / gpuClockHz;
+
+    // return (cycles, time in seconds, measured bandwidth)
+    return {timingResult[0], timeS, dataGiB / timeS};
+}
+
+
+// Constant memory is limited to 64 KiB and L1 is only a few KiB.
+// Cap size and threads so every thread reads at least one element.
+static size_t capConstantArraySize(size_t arraySizeBytes, const char* benchmarkName)
+{
+    if (arraySizeBytes > MAX_ALLOWED_SIZE) {
+        std::cerr << "WARNING: " << benchmarkName << " requested " << arraySizeBytes
+                  << " Bytes of constant data, capping to " << MAX_ALLOWED_SIZE << " Bytes" << std::endl;
+        arraySizeBytes = MAX_ALLOWED_SIZE;
+    }
+
+    return arraySizeBytes;
+}
+
+static uint32_t capNumThreads(size_t arraySizeBytes)
+{
+    size_t totalElements = arraySizeBytes / sizeof(uint32_t);
+    uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+
+    return static_cast<uint32_t>(std::min(static_cast<size_t>(maxNumThreads), totalElements));
+}
+
+
+namespace benchmark
+{
+    namespace nvidia
+    {
+        double measureConstantL1ReadBandwidth(size_t arraySizeBytes)
+        {
+            arraySizeBytes = capConstantArraySize(arraySizeBytes, "Constant L1 Read Bandwidth");
+
+            uint32_t maxNumThreads = capNumThreads(arraySizeBytes);
+            size_t maxReps = MAX_REPS;
+
+            if (maxNumThreads == 0) {
+                std::cerr << "WARNING: Constant L1 Read Bandwidth working set too small to benchmark, skipping" << std::endl;
+                return 0.0;
+            }
+
+            std::vector<double> results(ROUNDS);
+
+            for (uint32_t i = 0; i < ROUNDS; ++i)
+            {
+                results[i] = std::get<2>(constantL1ReadBandwidthLauncher(arraySizeBytes, maxNumThreads, maxReps));
+            }
+
+            return util::average(results);
+        }
+
+        CacheBandwidthResult measureConstantL1ReadBandwidthSweep(size_t arraySizeBytes)
+        {
+            arraySizeBytes = capConstantArraySize(arraySizeBytes, "Constant L1 Read Bandwidth");
+
+            uint32_t minNumThreads = util::getDeviceProperties().warpSize;
+            uint32_t maxNumThreads = capNumThreads(arraySizeBytes);
+            size_t minReps = MIN_REPS;
+            size_t maxReps = MAX_REPS;
+
+            CacheBandwidthResult result{};
+            result.measuredBandwidth = 0.0;
+            result.dataBytes = arraySizeBytes;
+            result.cycles = 0;
+            result.time = 0.0;
+            result.numThreads = 0;
+            result.numBlocks = 1;
+            result.numReps = 0;
+
+            if (maxNumThreads < minNumThreads) {
+                std::cerr << "WARNING: Constant L1 Read Bandwidth working set too small for a full warp, skipping" << std::endl;
+                return result;
+            }
+
+            for (uint32_t numThreads = minNumThreads; numThreads <= maxNumThreads; numThreads *= 2)
+            {
+                std::vector<double> bandwidthResults;
+
+                result.threadsTested.push_back(numThreads);
+
+                for (size_t reps = minReps; reps <= maxReps; reps *= 2)
+                {
+                    if (numThreads == minNumThreads)
+                    {
+                        result.repsTested.push_back(reps);
+                    }
+
+                    auto [cycles, timeS, bandwidth] = constantL1ReadBandwidthLauncher(arraySizeBytes, numThreads, reps);
+
+                    bandwidthResults.push_back(bandwidth);
+
+                    if (bandwidth > result.measuredBandwidth)
+                    {
+                        result.measuredBandwidth = bandwidth;
+                        result.cycles = cycles;
+                        result.time = timeS;
+                        result.numThreads = numThreads;
+                        result.numReps = reps;
+                    }
+                }
+
+                result.bandwidthGridGiBs.push_back(bandwidthResults);
+            }
+
+            return result;
+        }
+    }
+}

--- a/src/benchmarks/bandwidth/nvidia_constantL1ReadBandwidth.hpp
+++ b/src/benchmarks/bandwidth/nvidia_constantL1ReadBandwidth.hpp
@@ -1,0 +1,29 @@
+#pragma once
+
+#include <cstddef>
+
+#include "typedef/cacheBandwidthResult.hpp"
+
+namespace benchmark {
+    namespace nvidia {
+        /**
+         * @brief Measure achievable constant L1 cache read bandwidth of a single
+         *        MultiProcessor.
+         *
+         * @param arraySizeBytes Size of the constant array region in bytes used for the test.
+         *                       Should fit into the constant L1 so the timed loop hits it.
+         * @return Bandwidth in GiB/s.
+         */
+        double measureConstantL1ReadBandwidth(size_t arraySizeBytes);
+
+        /**
+         * @brief Measure constant L1 cache read bandwidth of a single MultiProcessor
+         *        with optimal number search for threads and reps.
+         *
+         * @param arraySizeBytes Size of the constant array region in bytes used for the test.
+         *                       Should fit into the constant L1 so the timed loop hits it.
+         * @return Bandwidth in GiB/s and the optimal configuration.
+         */
+        CacheBandwidthResult measureConstantL1ReadBandwidthSweep(size_t arraySizeBytes);
+    }
+}

--- a/src/benchmarks/benchmark.hpp
+++ b/src/benchmarks/benchmark.hpp
@@ -79,6 +79,8 @@
 
 #include "benchmarks/bandwidth/nvidia_readOnlyReadBandwidth.hpp"
 #include "benchmarks/bandwidth/nvidia_textureReadBandwidth.hpp"
+#include "benchmarks/bandwidth/nvidia_constantL1ReadBandwidth.hpp"
+#include "benchmarks/bandwidth/nvidia_constantL15ReadBandwidth.hpp"
 
 #include "benchmarks/share/nvidia_constantL1SharedWithL1.hpp"
 #include "benchmarks/share/nvidia_readOnlySharedWithL1.hpp"

--- a/src/config.hpp
+++ b/src/config.hpp
@@ -13,5 +13,8 @@ inline constexpr size_t DEFAULT_ROUNDS = 10; // Bandwidth rounds
 // increase MAX_REPS to restore the full sweep.
 inline constexpr size_t MIN_REPS = 2048; // 2^11
 inline constexpr size_t MAX_REPS = 2048; // 2^11
+// Early termination threshold for block/thread bandwidth sweeps.
+// A drop of >=25% from the reference bandwidth ends that sweep.
+inline constexpr double BANDWIDTH_EARLY_TERMINATION_FACTOR = 0.75; // Fraction
 inline constexpr size_t DEFAULT_SIZE_DOWN_FACTOR = 4; // Bandwidth benchmark test size reduction factor
 inline constexpr double SHARED_THRESHOLD = 2.5; // Threshold divisor to determine wether a measure cache latency counts as evicted or not

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -25,23 +25,31 @@ static constexpr auto MIN_EXPECTED_LINE_SIZE = 4;// Bytes
 static constexpr auto VALIDITY_THRESHOLD = 0.5;// Factor
 
 namespace {
-    // RAII wall-clock timer for a benchmark scope. Records elapsed time on scope
-    // exit; when disabled, it is a no-op.
+    // Wall-clock timer for a single benchmark. Wrap an invocation in operator()
+    // to time its full execution; the benchmark result is passed through unchanged.
+    // When disabled, it only invokes the benchmark.
     struct BenchTimer {
-        std::vector<std::pair<std::string, double>>& sink;
-        std::string name;
-        bool enabled;
-        std::chrono::steady_clock::time_point start;
+        std::vector<std::pair<std::string, double>> timings;
+        bool enabled = false;
 
-        BenchTimer(std::vector<std::pair<std::string, double>>& sink, std::string name, bool enabled)
-            : sink(sink), name(std::move(name)), enabled(enabled),
-              start(std::chrono::steady_clock::now()) {}
+        template <typename F>
+        auto operator()(const std::string& name, F&& benchmarkCall) {
+            const auto start = std::chrono::steady_clock::now();
+            if constexpr (std::is_void_v<decltype(benchmarkCall())>) {
+                benchmarkCall();
+                record(name, start);
+            } else {
+                auto value = benchmarkCall();
+                record(name, start);
+                return value;
+            }
+        }
 
-        ~BenchTimer() {
+        void record(const std::string& name, std::chrono::steady_clock::time_point start) {
             if (!enabled) return;
             double seconds = std::chrono::duration<double>(
                 std::chrono::steady_clock::now() - start).count();
-            sink.emplace_back(name, seconds);
+            timings.emplace_back(name, seconds);
             std::cout << "[Timing] " << name << " took " << seconds << " s" << std::endl;
         }
     };
@@ -256,28 +264,27 @@ int main(int argc, char* argv[]) {
     #endif
 
     // Timing instrumentation (-t/--timing). Times the full benchmark run here;
-    // individual benchmark groups are timed with BenchTimer.
-    std::vector<std::pair<std::string, double>> benchTimings;
+    // every individual benchmark is timed by wrapping its call in `timed`.
+    BenchTimer timed{{}, opts.timing};
     auto totalStart = std::chrono::steady_clock::now();
 
     if (opts.runL1) {
-        BenchTimer _timer(benchTimings, "L1", opts.timing);
         std::cout << "[L1] Starting Benchmarks" << std::endl;
         std::cout << "[L1] Latency" << std::endl;
-        CacheLatencyResult l1Latency = benchmark::measureL1Latency();
+        CacheLatencyResult l1Latency = timed("l1Latency", [&] { return benchmark::measureL1Latency(); });
         result["memory"]["l1"]["latency"] = l1Latency;
 
         std::cout << "[L1] Fetch Granularity" << std::endl;
-        CacheSizeResult l1FetchGranularity = benchmark::measureL1FetchGranularity();
+        CacheSizeResult l1FetchGranularity = timed("l1FetchGranularity", [&] { return benchmark::measureL1FetchGranularity(); });
         result["memory"]["l1"]["fetchGranularity"] = l1FetchGranularity;
 
         std::cout << "[L1] Size" << std::endl;
-        CacheSizeResult l1Size = benchmark::measureL1Size(l1FetchGranularity.confidence > VALIDITY_THRESHOLD ? l1FetchGranularity.size : MIN_EXPECTED_LINE_SIZE);
+        CacheSizeResult l1Size = timed("l1CacheSize", [&] { return benchmark::measureL1Size(l1FetchGranularity.confidence > VALIDITY_THRESHOLD ? l1FetchGranularity.size : MIN_EXPECTED_LINE_SIZE); });
         result["memory"]["l1"]["size"] = l1Size;
 
         if (l1FetchGranularity.confidence > VALIDITY_THRESHOLD && l1Size.confidence > VALIDITY_THRESHOLD) {
             std::cout << "[L1] Line Size" << std::endl;
-            CacheLineSizeResult l1LineSize = benchmark::measureL1LineSize(l1Size.size, l1FetchGranularity.size);
+            CacheLineSizeResult l1LineSize = timed("l1LineSize", [&] { return benchmark::measureL1LineSize(l1Size.size, l1FetchGranularity.size); });
             result["memory"]["l1"]["lineSize"] = l1LineSize;
             if (opts.graphs) {
                 util::exportChartsReduced(l1LineSize.timings, util::average<uint32_t>, fancyName + " - L1 Line Size", {}, "Bytes", "Cycles", graphDir.string());
@@ -288,14 +295,14 @@ int main(int argc, char* argv[]) {
 
             if (l1LineSize.confidence > VALIDITY_THRESHOLD) {
                 std::cout << "[L1] Miss Penalty" << std::endl;
-                double l1MissPenalty = benchmark::measureL1MissPenalty(l1Size.size, l1LineSize.size, l1Latency.mean);
+                double l1MissPenalty = timed("l1MissPenalty", [&] { return benchmark::measureL1MissPenalty(l1Size.size, l1LineSize.size, l1Latency.mean); });
                 result["memory"]["l1"]["missPenalty"] = {
                     {"value", l1MissPenalty},
                     {"unit", "cycles"}
                 };
 
                 std::cout << "[L1] Amount" << std::endl;
-                auto l1Amount = benchmark::measureL1Amount(l1Size.size, l1FetchGranularity.size, l1MissPenalty);
+                auto l1Amount = timed("l1Amount", [&] { return benchmark::measureL1Amount(l1Size.size, l1FetchGranularity.size, l1MissPenalty); });
                 if (l1Amount.has_value()) {
                     result["memory"]["l1"]["amountPerMultiprocessor"] = *l1Amount;
                 } else {
@@ -316,9 +323,9 @@ int main(int argc, char* argv[]) {
                 CacheBandwidthResult l1ReadBandwidth;
                 if (util::isAMD()) 
                 {
-                    l1ReadBandwidth = benchmark::amd::measureL1ReadBandwidthBlockSweep(l1Size.size / 2);
+                    l1ReadBandwidth = timed("amd_l1ReadBandwidthBlocksweep", [&] { return benchmark::amd::measureL1ReadBandwidthBlockSweep(l1Size.size / 2); });
                 } else {
-                    l1ReadBandwidth = benchmark::measureL1ReadBandwidthSweep(l1Size.size / 2);
+                    l1ReadBandwidth = timed("l1ReadBandwidth", [&] { return benchmark::measureL1ReadBandwidthSweep(l1Size.size / 2); });
                 }
                 result["memory"]["l1"]["readBandwidthPerCU"] = l1ReadBandwidth;
 
@@ -326,9 +333,9 @@ int main(int argc, char* argv[]) {
                 CacheBandwidthResult l1WriteBandwidth;
                 if (util::isAMD())
                 {
-                    l1WriteBandwidth = benchmark::amd::measureL1WriteBandwidthBlockSweep(l1Size.size / 2);
+                    l1WriteBandwidth = timed("amd_l1WriteBandwidthBlocksweep", [&] { return benchmark::amd::measureL1WriteBandwidthBlockSweep(l1Size.size / 2); });
                 } else {
-                    l1WriteBandwidth = benchmark::measureL1WriteBandwidthSweep(l1Size.size / 2);
+                    l1WriteBandwidth = timed("l1WriteBandwidth", [&] { return benchmark::measureL1WriteBandwidthSweep(l1Size.size / 2); });
                 }
                 result["memory"]["l1"]["writeBandwidthPerCU"] = l1WriteBandwidth;
 
@@ -346,13 +353,13 @@ int main(int argc, char* argv[]) {
             {
                 std::cout << "[L1] Read Bandwidth per CU / MultiProcessor" << std::endl;
                 result["memory"]["l1"]["readBandwidthPerCU"] = {
-                    {"value", benchmark::measureL1ReadBandwidth(l1Size.size / 2)},
+                    {"value", timed("l1ReadBandwidth", [&] { return benchmark::measureL1ReadBandwidth(l1Size.size / 2); })},
                     {"unit", "GiB/s"}
                 };
 
                 std::cout << "[L1] Write Bandwidth per CU / MultiProcessor" << std::endl;
                 result["memory"]["l1"]["writeBandwidthPerCU"] = {
-                    {"value", benchmark::measureL1WriteBandwidth(l1Size.size / 2)},
+                    {"value", timed("l1WriteBandwidth", [&] { return benchmark::measureL1WriteBandwidth(l1Size.size / 2); })},
                     {"unit", "GiB/s"}
                 };
             }
@@ -374,21 +381,20 @@ int main(int argc, char* argv[]) {
     }
 
     if (opts.runL2) {
-        BenchTimer _timer(benchTimings, "L2", opts.timing);
         std::cout << "[L2] Starting Benchmarks" << std::endl;
         std::cout << "[L2] Latency" << std::endl;
-        CacheLatencyResult l2Latency = benchmark::measureL2Latency();
+        CacheLatencyResult l2Latency = timed("l2Latency", [&] { return benchmark::measureL2Latency(); });
         result["memory"]["l2"]["latency"] = l2Latency;
 
         std::cout << "[L2] Fetch Granularity" << std::endl;
-        CacheSizeResult l2FetchGranularity = benchmark::measureL2FetchGranularity();
+        CacheSizeResult l2FetchGranularity = timed("l2FetchGranularity", [&] { return benchmark::measureL2FetchGranularity(); });
         result["memory"]["l2"]["fetchGranularity"] = l2FetchGranularity;
 
         if (util::isAMD()) {
             std::cout << "L2 Segment Size is currently broken on AMD. Skipping." << std::endl;
         } else {
             std::cout << "[L2] Segment Size" << std::endl;
-            CacheSizeResult l2SegmentSize = benchmark::measureL2SegmentSize(deviceProperties.l2CacheSize, l2FetchGranularity.confidence > VALIDITY_THRESHOLD ? l2FetchGranularity.size : MIN_EXPECTED_LINE_SIZE);
+            CacheSizeResult l2SegmentSize = timed("l2SegmentSize", [&] { return benchmark::measureL2SegmentSize(deviceProperties.l2CacheSize, l2FetchGranularity.confidence > VALIDITY_THRESHOLD ? l2FetchGranularity.size : MIN_EXPECTED_LINE_SIZE); });
             result["memory"]["l2"]["segmentSize"] = l2SegmentSize;
             if (opts.graphs) {
                 util::exportChartMinMaxAvgRed(l2SegmentSize.timings, fancyName + " - L2 Segment Size", {l2SegmentSize.size}, "Bytes", "Cycles", graphDir.string());
@@ -403,7 +409,7 @@ int main(int argc, char* argv[]) {
         if (!l2LineSizeValue.has_value()) {
             if (l2FetchGranularity.confidence > VALIDITY_THRESHOLD) {
                 std::cout << "[L2] Line Size" << std::endl;
-                CacheLineSizeResult l2LineSize = benchmark::measureL2LineSize(deviceProperties.l2CacheSize, l2FetchGranularity.size); // Unreliable on AMD because L2 Size Benchmarks are complicated
+                CacheLineSizeResult l2LineSize = timed("l2LineSize", [&] { return benchmark::measureL2LineSize(deviceProperties.l2CacheSize, l2FetchGranularity.size); }); // Unreliable on AMD because L2 Size Benchmarks are complicated
                 result["memory"]["l2"]["lineSize"] = l2LineSize;
                 if (opts.graphs) {
                     util::exportChartsReduced(l2LineSize.timings, util::average<uint32_t>, fancyName + " - L2 Line Size", {}, "Bytes", "Cycles", graphDir.string());
@@ -420,7 +426,7 @@ int main(int argc, char* argv[]) {
         }
         if (l2LineSizeValue.has_value()) {
             std::cout << "[L2] Miss Penalty" << std::endl;
-            double l2MissPenalty = benchmark::measureL2MissPenalty(deviceProperties.l2CacheSize, l2LineSizeValue.value(), l2Latency.mean);
+            double l2MissPenalty = timed("l2MissPenalty", [&] { return benchmark::measureL2MissPenalty(deviceProperties.l2CacheSize, l2LineSizeValue.value(), l2Latency.mean); });
             result["memory"]["l2"]["missPenalty"] = {
                 {"value", l2MissPenalty},
                 {"unit", "cycles"}
@@ -432,11 +438,11 @@ int main(int argc, char* argv[]) {
         if (opts.runOptimalSearch)
         {
             std::cout << "[L2] Read Bandwidth with optimal search" << std::endl;
-            CacheBandwidthResult l2ReadBandwidth = benchmark::measureL2ReadBandwidthSweep(deviceProperties.l2CacheSize);
+            CacheBandwidthResult l2ReadBandwidth = timed("l2ReadBandwidth", [&] { return benchmark::measureL2ReadBandwidthSweep(deviceProperties.l2CacheSize); });
             result["memory"]["l2"]["readBandwidth"] = l2ReadBandwidth;
 
             std::cout << "[L2] Write Bandwidth with optimal search" << std::endl;
-            CacheBandwidthResult l2WriteBandwidth = benchmark::measureL2WriteBandwidthSweep(deviceProperties.l2CacheSize);
+            CacheBandwidthResult l2WriteBandwidth = timed("l2WriteBandwidth", [&] { return benchmark::measureL2WriteBandwidthSweep(deviceProperties.l2CacheSize); });
             result["memory"]["l2"]["writeBandwidth"] = l2WriteBandwidth;
 
             if (opts.rawData || opts.graphs)
@@ -449,12 +455,12 @@ int main(int argc, char* argv[]) {
         {
             std::cout << "[L2] Read Bandwidth" << std::endl;
             result["memory"]["l2"]["readBandwidth"] = {
-                {"value", benchmark::measureL2ReadBandwidth(deviceProperties.l2CacheSize)},
+                {"value", timed("l2ReadBandwidth", [&] { return benchmark::measureL2ReadBandwidth(deviceProperties.l2CacheSize); })},
                 {"unit", "GiB/s"}
             };
             std::cout << "[L2] Write Bandwidth" << std::endl;
             result["memory"]["l2"]["writeBandwidth"] = {
-                {"value", benchmark::measureL2WriteBandwidth(deviceProperties.l2CacheSize)},
+                {"value", timed("l2WriteBandwidth", [&] { return benchmark::measureL2WriteBandwidth(deviceProperties.l2CacheSize); })},
                 {"unit", "GiB/s"}
             };
         }
@@ -471,7 +477,6 @@ int main(int argc, char* argv[]) {
     }
 
     if (opts.runL3) {
-        BenchTimer _timer(benchTimings, "L3", opts.timing);
         std::cout << "[L3] Starting Benchmarks" << std::endl;
         auto l3Size = util::getL3SizeBytes();
 
@@ -482,7 +487,7 @@ int main(int argc, char* argv[]) {
             };
 
             std::cout << "[L3] Latency" << std::endl;
-            CacheLatencyResult l3Latency = benchmark::amd::measureL3Latency(deviceProperties.l2CacheSize, 128);
+            CacheLatencyResult l3Latency = timed("amd_l3Latency", [&] { return benchmark::amd::measureL3Latency(deviceProperties.l2CacheSize, 128); });
             result["memory"]["l3"]["latency"] = l3Latency;
 
             /* Not working yet
@@ -493,7 +498,7 @@ int main(int argc, char* argv[]) {
             auto l3LineSize = util::getNumeric<size_t>(result, "memory", "l3", "lineSize", "value");
             if (l3LineSize.has_value()) {
                 std::cout << "[L3] Miss Penalty" << std::endl;
-                result["memory"]["l3"]["missPenalty"] = benchmark::amd::measureL3MissPenalty(l3Size.value(), l3LineSize.value(), l3Latency.mean);
+                result["memory"]["l3"]["missPenalty"] = timed("amd_l3MissPenalty", [&] { return benchmark::amd::measureL3MissPenalty(l3Size.value(), l3LineSize.value(), l3Latency.mean); });
             } else {
                 std::cout << "Could not determine L3 Line Size, L3 Line Size will not be part of the output + skipping Miss Penalty benchmarks." << std::endl;
             }
@@ -501,11 +506,11 @@ int main(int argc, char* argv[]) {
             if (opts.runOptimalSearch)
             {
                 std::cout << "[L3] Read Bandwidth with optimal search" << std::endl;
-                CacheBandwidthResult l3ReadBandwidth = benchmark::amd::measureL3ReadBandwidthSweep(deviceProperties.l2CacheSize, l3Size.value());
+                CacheBandwidthResult l3ReadBandwidth = timed("amd_l3ReadBandwidth", [&] { return benchmark::amd::measureL3ReadBandwidthSweep(deviceProperties.l2CacheSize, l3Size.value()); });
                 result["memory"]["l3"]["readBandwidth"] = l3ReadBandwidth;
 
                 std::cout << "[L3] Write Bandwidth with optimal search" << std::endl;
-                CacheBandwidthResult l3WriteBandwidth = benchmark::amd::measureL3WriteBandwidthSweep(deviceProperties.l2CacheSize, l3Size.value());
+                CacheBandwidthResult l3WriteBandwidth = timed("amd_l3WriteBandwidth", [&] { return benchmark::amd::measureL3WriteBandwidthSweep(deviceProperties.l2CacheSize, l3Size.value()); });
                 result["memory"]["l3"]["writeBandwidth"] = l3WriteBandwidth;
 
                 if (opts.rawData || opts.graphs)
@@ -518,13 +523,13 @@ int main(int argc, char* argv[]) {
             {
                 std::cout << "[L3] Read Bandwidth" << std::endl;
                 result["memory"]["l3"]["readBandwidth"] = {
-                    {"value", benchmark::amd::measureL3ReadBandwidth(deviceProperties.l2CacheSize, l3Size.value())},
+                    {"value", timed("amd_l3ReadBandwidth", [&] { return benchmark::amd::measureL3ReadBandwidth(deviceProperties.l2CacheSize, l3Size.value()); })},
                     {"unit", "GiB/s"}
                 };
 
                 std::cout << "[L3] Write Bandwidth" << std::endl;
                 result["memory"]["l3"]["writeBandwidth"] = {
-                    {"value", benchmark::amd::measureL3WriteBandwidth(deviceProperties.l2CacheSize, l3Size.value())},
+                    {"value", timed("amd_l3WriteBandwidth", [&] { return benchmark::amd::measureL3WriteBandwidth(deviceProperties.l2CacheSize, l3Size.value()); })},
                     {"unit", "GiB/s"}
                 };
             }
@@ -548,28 +553,27 @@ int main(int argc, char* argv[]) {
     }
 
     if (opts.runConstant) {
-        BenchTimer _timer(benchTimings, "Constant", opts.timing);
         std::cout << "[Constant] Starting Benchmarks" << std::endl;
         std::cout << "[Constant] L1 Latency" << std::endl;
-        CacheLatencyResult constantL1Latency = benchmark::nvidia::measureConstantL1Latency();
+        CacheLatencyResult constantL1Latency = timed("nvidia_constantL1Latency", [&] { return benchmark::nvidia::measureConstantL1Latency(); });
         result["memory"]["constant"]["l1"]["latency"] = constantL1Latency;
 
         std::cout << "[Constant] L1 Fetch Granularity" << std::endl;
-        CacheSizeResult constantL1FetchGranularity = benchmark::nvidia::measureConstantL1FetchGranularity();
+        CacheSizeResult constantL1FetchGranularity = timed("nvidia_constantL1FetchGranularity", [&] { return benchmark::nvidia::measureConstantL1FetchGranularity(); });
         result["memory"]["constant"]["l1"]["fetchGranularity"] = constantL1FetchGranularity;
 
         std::cout << "[Constant] L1.5 Fetch Granularity" << std::endl;
-        CacheSizeResult constantL15FetchGranularity = benchmark::nvidia::measureConstantL15FetchGranularity(constantL1FetchGranularity.size);
+        CacheSizeResult constantL15FetchGranularity = timed("nvidia_constantL15FetchGranularity", [&] { return benchmark::nvidia::measureConstantL15FetchGranularity(constantL1FetchGranularity.size); });
         result["memory"]["constant"]["l1.5"]["fetchGranularity"] = constantL15FetchGranularity;
 
-        CacheSizeResult constantL1Size = benchmark::nvidia::measureConstantL1Size(constantL1FetchGranularity.size);
-        CacheSizeResult constantL15Size = benchmark::nvidia::measureConstantL15Size(constantL15FetchGranularity.size);
+        CacheSizeResult constantL1Size = timed("nvidia_constantL1CacheSize", [&] { return benchmark::nvidia::measureConstantL1Size(constantL1FetchGranularity.size); });
+        CacheSizeResult constantL15Size = timed("nvidia_constantL15CacheSize", [&] { return benchmark::nvidia::measureConstantL15Size(constantL15FetchGranularity.size); });
         result["memory"]["constant"]["l1"]["size"] = constantL1Size;
         result["memory"]["constant"]["l1.5"]["size"] = constantL15Size;
 
         if (constantL1Size.confidence > VALIDITY_THRESHOLD && constantL1FetchGranularity.confidence > VALIDITY_THRESHOLD) {
             std::cout << "[Constant] L1 Line Size" << std::endl;
-            CacheLineSizeResult constantL1LineSize = benchmark::nvidia::measureConstantL1LineSize(constantL1Size.size, constantL1FetchGranularity.size);
+            CacheLineSizeResult constantL1LineSize = timed("nvidia_constantL1LineSize", [&] { return benchmark::nvidia::measureConstantL1LineSize(constantL1Size.size, constantL1FetchGranularity.size); });
             result["memory"]["constant"]["l1"]["lineSize"] = constantL1LineSize;
             if (opts.graphs) {
                 util::exportChartsReduced(constantL1LineSize.timings, util::average<uint32_t>, fancyName + " - Constant L1 Line Size", {}, "Bytes", "Cycles", graphDir.string());
@@ -580,7 +584,7 @@ int main(int argc, char* argv[]) {
 
             if (constantL1LineSize.confidence > VALIDITY_THRESHOLD) {
                 std::cout << "[Constant] L1 Miss Penalty" << std::endl;
-                double constantL1MissPenalty = benchmark::nvidia::measureConstantL1MissPenalty(constantL1Size.size, constantL1LineSize.size, constantL1Latency.mean);
+                double constantL1MissPenalty = timed("nvidia_constantL1MissPenalty", [&] { return benchmark::nvidia::measureConstantL1MissPenalty(constantL1Size.size, constantL1LineSize.size, constantL1Latency.mean); });
                 result["memory"]["constant"]["l1"]["missPenalty"] = {
                     {"value", constantL1MissPenalty},
                     {"unit", "cycles"}
@@ -588,7 +592,7 @@ int main(int argc, char* argv[]) {
                 
                 
                 std::cout << "[Constant] L1 Amount" << std::endl;
-                auto constantL1Amount = benchmark::nvidia::measureConstantL1Amount(constantL1Size.size, constantL1FetchGranularity.size, constantL1MissPenalty);
+                auto constantL1Amount = timed("nvidia_constantL1Amount", [&] { return benchmark::nvidia::measureConstantL1Amount(constantL1Size.size, constantL1FetchGranularity.size, constantL1MissPenalty); });
                 if (constantL1Amount.has_value()) {
                     result["memory"]["constant"]["l1"]["amountPerMultiprocessor"] = *constantL1Amount;
                 } else {
@@ -599,7 +603,7 @@ int main(int argc, char* argv[]) {
             }
 
             std::cout << "[Constant] L1.5 Latency" << std::endl;
-            CacheLatencyResult constantL15Latency = benchmark::nvidia::measureConstantL15Latency(8 * KiB, constantL1FetchGranularity.size);
+            CacheLatencyResult constantL15Latency = timed("nvidia_constantL15Latency", [&] { return benchmark::nvidia::measureConstantL15Latency(8 * KiB, constantL1FetchGranularity.size); });
             result["memory"]["constant"]["l1.5"]["latency"] = constantL15Latency;
             if (opts.rawData) {
                 util::writeVectorToFile(constantL15Latency.timings, (graphDir / (fancyFileName + "__Constant_L1.5_Latency.txt")).string());
@@ -610,7 +614,7 @@ int main(int argc, char* argv[]) {
 
         if (constantL15Size.confidence > VALIDITY_THRESHOLD && constantL1FetchGranularity.confidence > VALIDITY_THRESHOLD) {
             std::cout << "[Constant] L1.5 Line Size" << std::endl;
-            CacheLineSizeResult constantL15LineSize = benchmark::nvidia::measureConstantL15LineSize(constantL15Size.size, constantL15FetchGranularity.size);
+            CacheLineSizeResult constantL15LineSize = timed("nvidia_constantL15LineSize", [&] { return benchmark::nvidia::measureConstantL15LineSize(constantL15Size.size, constantL15FetchGranularity.size); });
             result["memory"]["constant"]["l1.5"]["lineSize"] = constantL15LineSize;
             if (opts.graphs) {
                 util::exportChartsReduced(constantL15LineSize.timings, util::average<uint32_t>, fancyName + " - Constant L1.5 Line Size", {}, "Bytes", "Cycles", graphDir.string());
@@ -621,6 +625,64 @@ int main(int argc, char* argv[]) {
         } else {
             std::cerr << "Could not measure valid Constant L1.5 Size or Fetch Granularity, skipping Constant L1.5 Line Size benchmarks." << std::endl;
         }
+
+        if (constantL1Size.confidence > VALIDITY_THRESHOLD) {
+            if (opts.runOptimalSearch)
+            {
+                std::cout << "[Constant] L1 Read Bandwidth per CU / MultiProcessor with optimal search" << std::endl;
+                CacheBandwidthResult constantL1ReadBandwidth = timed("nvidia_constantL1ReadBandwidth", [&] { return benchmark::nvidia::measureConstantL1ReadBandwidthSweep(constantL1Size.size / 2); });
+                result["memory"]["constant"]["l1"]["readBandwidthPerCU"] = constantL1ReadBandwidth;
+
+                if (opts.rawData || opts.graphs)
+                {
+                    util::writeBandwidthGridToCSV(constantL1ReadBandwidth, (graphDir / util::bandwidthGridFileName(fancyFileName, "ConstantL1", "Read")).string());
+                }
+            }
+            else
+            {
+                std::cout << "[Constant] L1 Read Bandwidth per CU / MultiProcessor" << std::endl;
+                result["memory"]["constant"]["l1"]["readBandwidthPerCU"] = {
+                    {"value", timed("nvidia_constantL1ReadBandwidth", [&] { return benchmark::nvidia::measureConstantL1ReadBandwidth(constantL1Size.size / 2); })},
+                    {"unit", "GiB/s"}
+                };
+            }
+        } else {
+            std::cout << "Could not measure valid Constant L1 Size, skipping Constant L1 Bandwidth benchmarks." << std::endl;
+        }
+
+        // No change point means the L1.5 spans the constant array, not that measurement failed.
+        // Bandwidth only needs a working set above L1 and within the array, so use half the
+        // constant array instead of skipping when confidence is zero.
+        size_t constantL15BandwidthBytes = constantL15Size.confidence > VALIDITY_THRESHOLD
+            ? constantL15Size.size / 2
+            : 32 * KiB;
+        // Stride by one fetch granularity per load so each access hits a fresh cache line.
+        // This avoids L1 reuse and isolates L1.5 bandwidth, matching the Constant L1.5
+        // Size and Latency benchmarks.
+        size_t constantL15BandwidthStride = constantL15FetchGranularity.confidence > VALIDITY_THRESHOLD
+            ? constantL15FetchGranularity.size
+            : MIN_EXPECTED_LINE_SIZE;
+
+        if (opts.runOptimalSearch)
+        {
+            std::cout << "[Constant] L1.5 Read Bandwidth per CU / MultiProcessor with optimal search" << std::endl;
+            CacheBandwidthResult constantL15ReadBandwidth = timed("nvidia_constantL15ReadBandwidth", [&] { return benchmark::nvidia::measureConstantL15ReadBandwidthSweep(constantL15BandwidthBytes, constantL15BandwidthStride); });
+            result["memory"]["constant"]["l1.5"]["readBandwidthPerCU"] = constantL15ReadBandwidth;
+
+            if (opts.rawData || opts.graphs)
+            {
+                util::writeBandwidthGridToCSV(constantL15ReadBandwidth, (graphDir / util::bandwidthGridFileName(fancyFileName, "ConstantL1.5", "Read")).string());
+            }
+        }
+        else
+        {
+            std::cout << "[Constant] L1.5 Read Bandwidth per CU / MultiProcessor" << std::endl;
+            result["memory"]["constant"]["l1.5"]["readBandwidthPerCU"] = {
+                {"value", timed("nvidia_constantL15ReadBandwidth", [&] { return benchmark::nvidia::measureConstantL15ReadBandwidth(constantL15BandwidthBytes, constantL15BandwidthStride); })},
+                {"unit", "GiB/s"}
+            };
+        }
+
         if (opts.graphs) {
             util::exportChartMinMaxAvgRed(constantL1Size.timings, fancyName + " - Constant L1 Size", {constantL1Size.size}, "Bytes", "Cycles", graphDir.string());
             util::exportChartsMinMaxAvg(constantL1FetchGranularity.timings, fancyName + " - Constant L1 Fetch Granularity", {constantL1FetchGranularity.size}, "Bytes", "Cycles", graphDir.string());
@@ -638,23 +700,22 @@ int main(int argc, char* argv[]) {
     }
 
     if (opts.runReadOnly) {
-        BenchTimer _timer(benchTimings, "Read Only", opts.timing);
         std::cout << "[Read Only] Starting Benchmarks" << std::endl;
         std::cout << "[Read Only] Latency" << std::endl;
-        CacheLatencyResult readOnlyLatency = benchmark::nvidia::measureReadOnlyLatency();
+        CacheLatencyResult readOnlyLatency = timed("nvidia_readOnlyLatency", [&] { return benchmark::nvidia::measureReadOnlyLatency(); });
         result["memory"]["readOnly"]["latency"] = readOnlyLatency;
 
         std::cout << "[Read Only] Fetch Granularity" << std::endl;
-        CacheSizeResult readOnlyFetchGranularity = benchmark::nvidia::measureReadOnlyFetchGranularity();
+        CacheSizeResult readOnlyFetchGranularity = timed("nvidia_readOnlyFetchGranularity", [&] { return benchmark::nvidia::measureReadOnlyFetchGranularity(); });
         result["memory"]["readOnly"]["fetchGranularity"] = readOnlyFetchGranularity;
 
         std::cout << "[Read Only] Size" << std::endl;
-        CacheSizeResult readOnlySize = benchmark::nvidia::measureReadOnlySize(readOnlyFetchGranularity.confidence > VALIDITY_THRESHOLD ? readOnlyFetchGranularity.size : MIN_EXPECTED_LINE_SIZE);
+        CacheSizeResult readOnlySize = timed("nvidia_readOnlyCacheSize", [&] { return benchmark::nvidia::measureReadOnlySize(readOnlyFetchGranularity.confidence > VALIDITY_THRESHOLD ? readOnlyFetchGranularity.size : MIN_EXPECTED_LINE_SIZE); });
         result["memory"]["readOnly"]["size"] = readOnlySize;
 
         if (readOnlySize.confidence > VALIDITY_THRESHOLD && readOnlyFetchGranularity.confidence > VALIDITY_THRESHOLD) {
             std::cout << "[Read Only] Line Size" << std::endl;
-            CacheLineSizeResult readOnlyLineSize = benchmark::nvidia::measureReadOnlyLineSize(readOnlySize.size, readOnlyFetchGranularity.size);
+            CacheLineSizeResult readOnlyLineSize = timed("nvidia_readOnlyLineSize", [&] { return benchmark::nvidia::measureReadOnlyLineSize(readOnlySize.size, readOnlyFetchGranularity.size); });
             result["memory"]["readOnly"]["lineSize"] = readOnlyLineSize;
             if (opts.graphs) {
                 util::exportChartsReduced(readOnlyLineSize.timings, util::average<uint32_t>, fancyName + " - Read Only Line Size", {}, "Bytes", "Cycles", graphDir.string());
@@ -665,14 +726,14 @@ int main(int argc, char* argv[]) {
 
             if (readOnlyLineSize.confidence > VALIDITY_THRESHOLD) {
                 std::cout << "[Read Only] Miss Penalty" << std::endl;
-                double readOnlyMissPenalty = benchmark::nvidia::measureReadOnlyMissPenalty(readOnlySize.size, readOnlyLineSize.size, readOnlyLatency.mean);
+                double readOnlyMissPenalty = timed("nvidia_readOnlyMissPenalty", [&] { return benchmark::nvidia::measureReadOnlyMissPenalty(readOnlySize.size, readOnlyLineSize.size, readOnlyLatency.mean); });
                 result["memory"]["readOnly"]["missPenalty"] = {
                     {"value", readOnlyMissPenalty},
                     {"unit", "cycles"}
                 };
 
                 std::cout << "[Read Only] Amount" << std::endl;
-                auto readOnlyAmount = benchmark::nvidia::measureReadOnlyAmount(readOnlySize.size, readOnlyFetchGranularity.size, readOnlyMissPenalty);
+                auto readOnlyAmount = timed("nvidia_readOnlyAmount", [&] { return benchmark::nvidia::measureReadOnlyAmount(readOnlySize.size, readOnlyFetchGranularity.size, readOnlyMissPenalty); });
                 if (readOnlyAmount.has_value()) {
                     result["memory"]["readOnly"]["amountPerMultiprocessor"] = *readOnlyAmount;
                 } else {
@@ -688,7 +749,7 @@ int main(int argc, char* argv[]) {
         if (readOnlySize.confidence > VALIDITY_THRESHOLD) {
             if (opts.runOptimalSearch) {
                 std::cout << "[Read Only] Read Bandwidth per CU / MultiProcessor with optimal search" << std::endl;
-                CacheBandwidthResult readOnlyReadBandwidth = benchmark::nvidia::measureReadOnlyReadBandwidthSweep(readOnlySize.size / 2);
+                CacheBandwidthResult readOnlyReadBandwidth = timed("nvidia_readOnlyReadBandwidth", [&] { return benchmark::nvidia::measureReadOnlyReadBandwidthSweep(readOnlySize.size / 2); });
                 result["memory"]["readOnly"]["readBandwidthPerCU"] = readOnlyReadBandwidth;
 
                 if (opts.rawData || opts.graphs) {
@@ -697,7 +758,7 @@ int main(int argc, char* argv[]) {
             } else {
                 std::cout << "[Read Only] Read Bandwidth per CU / MultiProcessor" << std::endl;
                 result["memory"]["readOnly"]["readBandwidthPerCU"] = {
-                    {"value", benchmark::nvidia::measureReadOnlyReadBandwidth(readOnlySize.size / 2)},
+                    {"value", timed("nvidia_readOnlyReadBandwidth", [&] { return benchmark::nvidia::measureReadOnlyReadBandwidth(readOnlySize.size / 2); })},
                     {"unit", "GiB/s"}
                 };
             }
@@ -718,23 +779,22 @@ int main(int argc, char* argv[]) {
     }
 
     if (opts.runTexture) {
-        BenchTimer _timer(benchTimings, "Texture", opts.timing);
         std::cout << "[Texture] Starting Benchmarks" << std::endl;
         std::cout << "[Texture] Latency" << std::endl;
-        CacheLatencyResult textureLatency = benchmark::nvidia::measureTextureLatency();
+        CacheLatencyResult textureLatency = timed("nvidia_textureLatency", [&] { return benchmark::nvidia::measureTextureLatency(); });
         result["memory"]["texture"]["latency"] = textureLatency;
 
         std::cout << "[Texture] Fetch Granularity" << std::endl;
-        CacheSizeResult textureFetchGranularity = benchmark::nvidia::measureTextureFetchGranularity();
+        CacheSizeResult textureFetchGranularity = timed("nvidia_textureFetchGranularity", [&] { return benchmark::nvidia::measureTextureFetchGranularity(); });
         result["memory"]["texture"]["fetchGranularity"] = textureFetchGranularity;
 
         std::cout << "[Texture] Size" << std::endl;
-        CacheSizeResult textureSize = benchmark::nvidia::measureTextureSize(textureFetchGranularity.confidence > VALIDITY_THRESHOLD ? textureFetchGranularity.size : MIN_EXPECTED_LINE_SIZE);
+        CacheSizeResult textureSize = timed("nvidia_textureCacheSize", [&] { return benchmark::nvidia::measureTextureSize(textureFetchGranularity.confidence > VALIDITY_THRESHOLD ? textureFetchGranularity.size : MIN_EXPECTED_LINE_SIZE); });
         result["memory"]["texture"]["size"] = textureSize;
 
         if (textureSize.confidence > VALIDITY_THRESHOLD && textureFetchGranularity.confidence > VALIDITY_THRESHOLD) {
             std::cout << "[Texture] Line Size" << std::endl;
-            CacheLineSizeResult textureLineSize = benchmark::nvidia::measureTextureLineSize(textureSize.size, textureFetchGranularity.size);
+            CacheLineSizeResult textureLineSize = timed("nvidia_textureLineSize", [&] { return benchmark::nvidia::measureTextureLineSize(textureSize.size, textureFetchGranularity.size); });
             result["memory"]["texture"]["lineSize"] = textureLineSize;
             if (opts.graphs) {
                 util::exportChartsReduced(textureLineSize.timings, util::average<uint32_t>, fancyName + " - Texture Line Size", {}, "Bytes", "Cycles", graphDir.string());
@@ -745,14 +805,14 @@ int main(int argc, char* argv[]) {
 
             if (textureLineSize.confidence > VALIDITY_THRESHOLD) {
                 std::cout << "[Texture] Miss Penalty" << std::endl;
-                double textureMissPenalty = benchmark::nvidia::measureTextureMissPenalty(textureSize.size, textureLineSize.size, textureLatency.mean);
+                double textureMissPenalty = timed("nvidia_textureMissPenalty", [&] { return benchmark::nvidia::measureTextureMissPenalty(textureSize.size, textureLineSize.size, textureLatency.mean); });
                 result["memory"]["texture"]["missPenalty"] = {
                     {"value", textureMissPenalty},
                     {"unit", "cycles"}
                 };
                 
                 std::cout << "[Texture] Amount" << std::endl;
-                auto textureAmount = benchmark::nvidia::measureTextureAmount(textureSize.size, textureFetchGranularity.size, textureMissPenalty);
+                auto textureAmount = timed("nvidia_textureAmount", [&] { return benchmark::nvidia::measureTextureAmount(textureSize.size, textureFetchGranularity.size, textureMissPenalty); });
                 if (textureAmount.has_value()) {
                     result["memory"]["texture"]["amountPerMultiprocessor"] = *textureAmount;
                 } else {
@@ -768,7 +828,7 @@ int main(int argc, char* argv[]) {
         if (textureSize.confidence > VALIDITY_THRESHOLD) {
             if (opts.runOptimalSearch) {
                 std::cout << "[Texture] Read Bandwidth per CU / MultiProcessor with optimal search" << std::endl;
-                CacheBandwidthResult textureReadBandwidth = benchmark::nvidia::measureTextureReadBandwidthSweep(textureSize.size / 2);
+                CacheBandwidthResult textureReadBandwidth = timed("nvidia_textureReadBandwidth", [&] { return benchmark::nvidia::measureTextureReadBandwidthSweep(textureSize.size / 2); });
                 result["memory"]["texture"]["readBandwidthPerCU"] = textureReadBandwidth;
 
                 if (opts.rawData || opts.graphs) {
@@ -777,7 +837,7 @@ int main(int argc, char* argv[]) {
             } else {
                 std::cout << "[Texture] Read Bandwidth per CU / MultiProcessor" << std::endl;
                 result["memory"]["texture"]["readBandwidthPerCU"] = {
-                    {"value", benchmark::nvidia::measureTextureReadBandwidth(textureSize.size / 2)},
+                    {"value", timed("nvidia_textureReadBandwidth", [&] { return benchmark::nvidia::measureTextureReadBandwidth(textureSize.size / 2); })},
                     {"unit", "GiB/s"}
                 };
             }
@@ -798,24 +858,23 @@ int main(int argc, char* argv[]) {
     }
 
     if (opts.runScalar) {
-        BenchTimer _timer(benchTimings, "Scalar L1", opts.timing);
         std::cout << "[Scalar L1] Starting Benchmarks" << std::endl;
         std::cout << "[Scalar L1] Latency" << std::endl;
-        CacheLatencyResult scalarL1Latency = benchmark::amd::measureScalarL1Latency();
+        CacheLatencyResult scalarL1Latency = timed("amd_scalarL1Latency", [&] { return benchmark::amd::measureScalarL1Latency(); });
         result["memory"]["scalarL1"]["latency"] = scalarL1Latency;
-        
+
         std::cout << "[Scalar L1] Fetch Granularity" << std::endl;
-        CacheSizeResult scalarL1FetchGranularity = benchmark::amd::measureScalarL1FetchGranularity();
+        CacheSizeResult scalarL1FetchGranularity = timed("amd_scalarL1FetchGranularity", [&] { return benchmark::amd::measureScalarL1FetchGranularity(); });
         result["memory"]["scalarL1"]["fetchGranularity"] = scalarL1FetchGranularity;
 
         std::cout << "[Scalar L1] Size" << std::endl;
-        CacheSizeResult scalarL1Size = benchmark::amd::measureScalarL1Size(scalarL1FetchGranularity.confidence > VALIDITY_THRESHOLD ? scalarL1FetchGranularity.size : MIN_EXPECTED_LINE_SIZE);
+        CacheSizeResult scalarL1Size = timed("amd_scalarL1CacheSize", [&] { return benchmark::amd::measureScalarL1Size(scalarL1FetchGranularity.confidence > VALIDITY_THRESHOLD ? scalarL1FetchGranularity.size : MIN_EXPECTED_LINE_SIZE); });
         result["memory"]["scalarL1"]["size"] = scalarL1Size;
 
 
         if (scalarL1Size.confidence > VALIDITY_THRESHOLD && scalarL1FetchGranularity.confidence > VALIDITY_THRESHOLD) {
             std::cout << "[Scalar L1] Line Size" << std::endl;
-            CacheLineSizeResult scalarL1LineSize = benchmark::amd::measureScalarL1LineSize(scalarL1Size.size, scalarL1FetchGranularity.size);
+            CacheLineSizeResult scalarL1LineSize = timed("amd_scalarL1LineSize", [&] { return benchmark::amd::measureScalarL1LineSize(scalarL1Size.size, scalarL1FetchGranularity.size); });
             result["memory"]["scalarL1"]["lineSize"] = scalarL1LineSize;
             if (opts.graphs) {
                 util::exportChartsReduced(scalarL1LineSize.timings, util::average<uint32_t>, fancyName + " - Scalar L1 Line Size", {}, "Bytes", "Cycles", graphDir.string());
@@ -826,7 +885,7 @@ int main(int argc, char* argv[]) {
 
             if (scalarL1LineSize.confidence > VALIDITY_THRESHOLD) {
                 std::cout << "[Scalar L1] Miss Penalty" << std::endl;
-                double scalarL1MissPenalty = benchmark::amd::measureScalarL1MissPenalty(scalarL1Size.size, scalarL1LineSize.size, scalarL1Latency.mean);
+                double scalarL1MissPenalty = timed("amd_scalarL1MissPenalty", [&] { return benchmark::amd::measureScalarL1MissPenalty(scalarL1Size.size, scalarL1LineSize.size, scalarL1Latency.mean); });
                 result["memory"]["scalarL1"]["missPenalty"] = {
                     {"value", scalarL1MissPenalty},
                     {"unit", "cycles"}
@@ -838,11 +897,11 @@ int main(int argc, char* argv[]) {
             if (opts.runOptimalSearch)
             {
                 std::cout << "[Scalar L1] Read Bandwidth per CU / MultiProcessor with optimal search" << std::endl;
-                CacheBandwidthResult sL1ReadBandwidth = benchmark::amd::measureScalarL1ReadBandwidthSweep(scalarL1Size.size / 2);
+                CacheBandwidthResult sL1ReadBandwidth = timed("amd_sL1ReadBandwidth", [&] { return benchmark::amd::measureScalarL1ReadBandwidthSweep(scalarL1Size.size / 2); });
                 result["memory"]["scalarL1"]["readBandwidthPerCU"] = sL1ReadBandwidth;
 
                 std::cout << "[Scalar L1] Write Bandwidth per CU / MultiProcessor with optimal search" << std::endl;
-                CacheBandwidthResult sL1WriteBandwidth = benchmark::amd::measureScalarL1WriteBandwidthSweep(scalarL1Size.size / 2);
+                CacheBandwidthResult sL1WriteBandwidth = timed("amd_sL1WriteBandwidth", [&] { return benchmark::amd::measureScalarL1WriteBandwidthSweep(scalarL1Size.size / 2); });
                 result["memory"]["scalarL1"]["writeBandwidthPerCU"] = sL1WriteBandwidth;
 
                 if (opts.rawData || opts.graphs)
@@ -855,13 +914,13 @@ int main(int argc, char* argv[]) {
             {
                 std::cout << "[Scalar L1] Read Bandwidth per CU / MultiProcessor" << std::endl;
                 result["memory"]["scalarL1"]["readBandwidthPerCU"] = {
-                    {"value", benchmark::amd::measureScalarL1ReadBandwidth(scalarL1Size.size / 2)},
+                    {"value", timed("amd_sL1ReadBandwidth", [&] { return benchmark::amd::measureScalarL1ReadBandwidth(scalarL1Size.size / 2); })},
                     {"unit", "GiB/s"}
                 };
 
                 std::cout << "[Scalar L1] Write Bandwidth per CU / MultiProcessor" << std::endl;
                 result["memory"]["scalarL1"]["writeBandwidthPerCU"] = {
-                    {"value", benchmark::amd::measureScalarL1WriteBandwidth(scalarL1Size.size / 2)},
+                    {"value", timed("amd_sL1WriteBandwidth", [&] { return benchmark::amd::measureScalarL1WriteBandwidth(scalarL1Size.size / 2); })},
                     {"unit", "GiB/s"}
                 };
             }
@@ -873,7 +932,7 @@ int main(int argc, char* argv[]) {
             }
             else
             {
-                auto sharedBetweenCUs = benchmark::amd::measureCuShareScalarL1(scalarL1Size.size, scalarL1FetchGranularity.size);
+                auto sharedBetweenCUs = timed("amd_cuShareScalarL1", [&] { return benchmark::amd::measureCuShareScalarL1(scalarL1Size.size, scalarL1FetchGranularity.size); });
                 result["memory"]["scalarL1"]["sharedBetween"] = sharedBetweenCUs;
                 result["memory"]["scalarL1"]["uniqueAmount"] = sharedBetweenCUs.size();
             }
@@ -895,10 +954,9 @@ int main(int argc, char* argv[]) {
     }
     
     if (opts.runSharedMemory) {
-        BenchTimer _timer(benchTimings, "Shared Memory", opts.timing);
         std::cout << "[Shared Memory] Starting Benchmarks" << std::endl;
         std::cout << "[Shared Memory] Latency" << std::endl;
-        CacheLatencyResult sharedLatency = benchmark::measureSharedMemoryLatency();
+        CacheLatencyResult sharedLatency = timed("sharedLatency", [&] { return benchmark::measureSharedMemoryLatency(); });
         result["memory"]["shared"]["latency"] = sharedLatency;
         if (opts.rawData) {
             util::writeVectorToFile(sharedLatency.timings, (graphDir / (fancyFileName + "__Shared_Memory_Latency.txt")).string());
@@ -910,9 +968,9 @@ int main(int argc, char* argv[]) {
             CacheBandwidthResult sharedReadBandwidth;
             if (opts.sharedStatic)
             {
-                sharedReadBandwidth = benchmark::measureSharedReadBandwidthStaticSweep();
+                sharedReadBandwidth = timed("sharedReadBandwidthStatic", [&] { return benchmark::measureSharedReadBandwidthStaticSweep(); });
             } else {
-                sharedReadBandwidth = benchmark::measureSharedReadBandwidthSweep(deviceProperties.sharedMemPerBlock / 2);
+                sharedReadBandwidth = timed("sharedReadBandwidth", [&] { return benchmark::measureSharedReadBandwidthSweep(deviceProperties.sharedMemPerBlock / 2); });
             }
             result["memory"]["shared"]["readBandwidthPerCU"] = sharedReadBandwidth;
 
@@ -920,9 +978,9 @@ int main(int argc, char* argv[]) {
             CacheBandwidthResult sharedWriteBandwidth;
             if (opts.sharedStatic)
             {
-                sharedWriteBandwidth = benchmark::measureSharedWriteBandwidthStaticSweep();
+                sharedWriteBandwidth = timed("sharedWriteBandwidthStatic", [&] { return benchmark::measureSharedWriteBandwidthStaticSweep(); });
             } else {
-                sharedWriteBandwidth = benchmark::measureSharedWriteBandwidthSweep(deviceProperties.sharedMemPerBlock / 2);
+                sharedWriteBandwidth = timed("sharedWriteBandwidth", [&] { return benchmark::measureSharedWriteBandwidthSweep(deviceProperties.sharedMemPerBlock / 2); });
             }
             result["memory"]["shared"]["writeBandwidthPerCU"] = sharedWriteBandwidth;
 
@@ -945,12 +1003,12 @@ int main(int argc, char* argv[]) {
             if (opts.sharedStatic)
             {
                 result["memory"]["shared"]["readBandwidthPerCU"] = {
-                    {"value", benchmark::measureSharedReadBandwidthStatic()},
+                    {"value", timed("sharedReadBandwidthStatic", [&] { return benchmark::measureSharedReadBandwidthStatic(); })},
                     {"unit", "GiB/s"}
                 };
             } else {
                 result["memory"]["shared"]["readBandwidthPerCU"] = {
-                    {"value", benchmark::measureSharedReadBandwidth(deviceProperties.sharedMemPerBlock / 2)},
+                    {"value", timed("sharedReadBandwidth", [&] { return benchmark::measureSharedReadBandwidth(deviceProperties.sharedMemPerBlock / 2); })},
                     {"unit", "GiB/s"}
                 };
             }
@@ -960,12 +1018,12 @@ int main(int argc, char* argv[]) {
             if (opts.sharedStatic)
             {
                 result["memory"]["shared"]["writeBandwidthPerCU"] = {
-                    {"value", benchmark::measureSharedWriteBandwidthStatic()},
+                    {"value", timed("sharedWriteBandwidthStatic", [&] { return benchmark::measureSharedWriteBandwidthStatic(); })},
                     {"unit", "GiB/s"}
                 };
             } else {
                 result["memory"]["shared"]["writeBandwidthPerCU"] = {
-                    {"value", benchmark::measureSharedWriteBandwidth(deviceProperties.sharedMemPerBlock / 2)},
+                    {"value", timed("sharedWriteBandwidth", [&] { return benchmark::measureSharedWriteBandwidth(deviceProperties.sharedMemPerBlock / 2); })},
                     {"unit", "GiB/s"}
                 };
             }
@@ -975,11 +1033,10 @@ int main(int argc, char* argv[]) {
     }
 
     if (opts.runMainMemory) {
-        BenchTimer _timer(benchTimings, "Main Memory", opts.timing);
         std::cout << "[Main Memory] Starting Benchmarks" << std::endl;
 
         std::cout << "[Main Memory] Latency" << std::endl;
-        CacheLatencyResult mainMemLatency = benchmark::measureMainMemoryLatency();
+        CacheLatencyResult mainMemLatency = timed("mainMemoryLatency", [&] { return benchmark::measureMainMemoryLatency(); });
         result["memory"]["main"]["latency"] = mainMemLatency;
         if (opts.rawData) {
             util::writeVectorToFile(mainMemLatency.timings, (graphDir / (fancyFileName + "__Main_Memory_Latency.txt")).string());
@@ -988,11 +1045,11 @@ int main(int argc, char* argv[]) {
         if (opts.runOptimalSearch)
         {
             std::cout << "[Main Memory] Read Bandwidth with optimal search" << std::endl;
-            CacheBandwidthResult mainMemReadBandwidth = benchmark::measureMainMemoryReadBandwidthSweep(deviceProperties.totalGlobalMem);
+            CacheBandwidthResult mainMemReadBandwidth = timed("mainMemoryReadBandwidth", [&] { return benchmark::measureMainMemoryReadBandwidthSweep(deviceProperties.totalGlobalMem); });
             result["memory"]["main"]["readBandwidth"] = mainMemReadBandwidth;
 
             std::cout << "[Main Memory] Write Bandwidth with optimal search" << std::endl;
-            CacheBandwidthResult mainMemWriteBandwidth = benchmark::measureMainMemoryWriteBandwidthSweep(deviceProperties.totalGlobalMem);
+            CacheBandwidthResult mainMemWriteBandwidth = timed("mainMemoryWriteBandwidth", [&] { return benchmark::measureMainMemoryWriteBandwidthSweep(deviceProperties.totalGlobalMem); });
             result["memory"]["main"]["writeBandwidth"] = mainMemWriteBandwidth;
 
             if (opts.rawData || opts.graphs)
@@ -1005,13 +1062,13 @@ int main(int argc, char* argv[]) {
         {
             std::cout << "[Main Memory] Read Bandwidth" << std::endl;
             result["memory"]["main"]["readBandwidth"] = {
-                {"value", benchmark::measureMainMemoryReadBandwidth(deviceProperties.totalGlobalMem)},
+                {"value", timed("mainMemoryReadBandwidth", [&] { return benchmark::measureMainMemoryReadBandwidth(deviceProperties.totalGlobalMem); })},
                 {"unit", "GiB/s"}
             };
 
             std::cout << "[Main Memory] Write Bandwidth" << std::endl;
             result["memory"]["main"]["writeBandwidth"] = {
-                {"value", benchmark::measureMainMemoryWriteBandwidth(deviceProperties.totalGlobalMem)},
+                {"value", timed("mainMemoryWriteBandwidth", [&] { return benchmark::measureMainMemoryWriteBandwidth(deviceProperties.totalGlobalMem); })},
                 {"unit", "GiB/s"}
             };
         }
@@ -1019,28 +1076,35 @@ int main(int argc, char* argv[]) {
         std::cout << "[Main Memory] Benchmarks finished" << std::endl;
     }
     if (opts.runResourceSharing) {
-        BenchTimer _timer(benchTimings, "Resource Sharing", opts.timing);
         std::cout << "[Resource Sharing] Starting Benchmarks" << std::endl;
 
         if (opts.runConstant && opts.runL1) {
-            util::sharedHelper(result["memory"]["constant"]["l1"], result["memory"]["l1"],
-                         "Constant L1", "L1",
-                         benchmark::nvidia::measureConstantL1AndL1Shared);
+            timed("nvidia_constantL1SharedWithL1", [&] {
+                util::sharedHelper(result["memory"]["constant"]["l1"], result["memory"]["l1"],
+                             "Constant L1", "L1",
+                             benchmark::nvidia::measureConstantL1AndL1Shared);
+            });
         }
         if (opts.runReadOnly && opts.runL1) {
-            util::sharedHelper(result["memory"]["readOnly"], result["memory"]["l1"],
-                         "Read Only", "L1",
-                         benchmark::nvidia::measureReadOnlyAndL1Shared);
+            timed("nvidia_readOnlySharedWithL1", [&] {
+                util::sharedHelper(result["memory"]["readOnly"], result["memory"]["l1"],
+                             "Read Only", "L1",
+                             benchmark::nvidia::measureReadOnlyAndL1Shared);
+            });
         }
         if (opts.runTexture && opts.runL1) {
-            util::sharedHelper(result["memory"]["texture"], result["memory"]["l1"],
-                         "Texture", "L1",
-                         benchmark::nvidia::measureTextureAndL1Shared);
+            timed("nvidia_textureSharedWithL1", [&] {
+                util::sharedHelper(result["memory"]["texture"], result["memory"]["l1"],
+                             "Texture", "L1",
+                             benchmark::nvidia::measureTextureAndL1Shared);
+            });
         }
         if (opts.runTexture && opts.runReadOnly) {
-            util::sharedHelper(result["memory"]["texture"], result["memory"]["readOnly"],
-                         "Texture", "Read Only",
-                         benchmark::nvidia::measureTextureAndReadOnlyShared);
+            timed("nvidia_textureSharedWithReadOnly", [&] {
+                util::sharedHelper(result["memory"]["texture"], result["memory"]["readOnly"],
+                             "Texture", "Read Only",
+                             benchmark::nvidia::measureTextureAndReadOnlyShared);
+            });
         }
 
         std::cout << "[Resource Sharing] Benchmarks finished" << std::endl;
@@ -1056,11 +1120,11 @@ int main(int argc, char* argv[]) {
     if (opts.timing) {
         double sumSeconds = 0.0;
         std::cout << "\n===== Timing Summary =====" << std::endl;
-        for (const auto& [name, seconds] : benchTimings) {
+        for (const auto& [name, seconds] : timed.timings) {
             std::cout << "  " << name << ": " << seconds << " s" << std::endl;
             sumSeconds += seconds;
         }
-        std::cout << "  Sum of benchmark groups: " << sumSeconds << " s" << std::endl;
+        std::cout << "  Sum of individual benchmarks: " << sumSeconds << " s" << std::endl;
         std::cout << "  Total execution time: " << totalSeconds << " s"
                   << " (" << totalSeconds / 60.0 << " min)" << std::endl;
     }

--- a/src/utils/printing.cpp
+++ b/src/utils/printing.cpp
@@ -71,7 +71,7 @@ namespace util {
                 cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
             ("static", "Runs shared memory bandwidth benchmarks with static allocated memory",
                 cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
-            ("t,timing", "Measure and print wall-clock time of the whole run and each benchmark group",
+            ("t,timing", "Measure and print wall-clock time of the whole run and each individual benchmark",
                 cxxopts::value<bool>()->default_value("false")->implicit_value("true"))
 
             // ------- Benchmark group toggles -------


### PR DESCRIPTION
- per benchmark timing instead of per group
- added constant and L1.5 cache benchmarks
- updated the blocks x threads sweep logic