### PR TITLE
Force Release build configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,11 @@ cmake_minimum_required(VERSION 3.21)
 # enabled per target architecture below instead of here.
 project(mt4g VERSION 1.2.0 LANGUAGES CXX)
 
+# MT4G always builds optimized; unoptimized device code can cause illegal
+# memory accesses on AMD CDNA3. FORCE also overrides -DCMAKE_BUILD_TYPE=...
+set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type (forced by MT4G)" FORCE)
+message(STATUS "CMAKE_BUILD_TYPE is set to Release by MT4G")
+
 set(GPU_TARGET_ARCH "" CACHE STRING "The target GPU architecture")
 if(GPU_TARGET_ARCH STREQUAL "")
     message(FATAL_ERROR "Please set GPU_TARGET_ARCH, e.g. -DGPU_TARGET_ARCH=sm_70 or -DGPU_TARGET_ARCH=gfx90a")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,9 +1,10 @@
 cmake_minimum_required(VERSION 3.21)
 
-# CMake 3.21+ supports HIP as a first-class language, which handles compiler
-# and HIP path discovery automatically. If CMake cannot find HIP, set HIP_PATH
-# and call find_package(hip REQUIRED CONFIG) manually as a fallback.
-project(mt4g VERSION 1.2.0 LANGUAGES CXX HIP)
+# CMake 3.21+ supports HIP as a first-class language, but its detection module
+# always requires a ROCm installation. On NVIDIA targets HIP is only a header
+# layer over CUDA and there is no ROCm root to find, so the HIP language is
+# enabled per target architecture below instead of here.
+project(mt4g VERSION 1.2.0 LANGUAGES CXX)
 
 set(GPU_TARGET_ARCH "" CACHE STRING "The target GPU architecture")
 if(GPU_TARGET_ARCH STREQUAL "")
@@ -36,10 +37,27 @@ set(CMAKE_CXX_EXTENSIONS OFF)
 
 if(GPU_TARGET_ARCH MATCHES "^sm_")
     set(ENV{HIP_PLATFORM} nvidia)
-    add_compile_options(--gpu-architecture=${GPU_TARGET_ARCH} -x cu -Wno-deprecated-gpu-targets)
+    # Do not pass -x cu here: hipcc classifies the input itself and adds it. An
+    # explicit -x cu makes hipcc treat the file as pre-classified and drop its
+    # own -isystem HIP include flags.
+    add_compile_options(--gpu-architecture=${GPU_TARGET_ARCH} -Wno-deprecated-gpu-targets)
     find_package(CUDAToolkit REQUIRED)
+    # A HIP SDK built for the NVIDIA backend may ship a CMake package config;
+    # if it does not (header-only HIP installations), hip::host is just the HIP
+    # include directory on top of the CUDA toolchain.
+    find_package(hip QUIET CONFIG)
+    if(NOT TARGET hip::host)
+        add_library(hip::host INTERFACE IMPORTED)
+        if(DEFINED ENV{HIP_PATH})
+            target_include_directories(hip::host INTERFACE $ENV{HIP_PATH}/include)
+        endif()
+    endif()
 elseif(GPU_TARGET_ARCH MATCHES "^gfx")
     set(ENV{HIP_PLATFORM} amd)
+    enable_language(HIP)
+    if(NOT TARGET hip::host)
+        find_package(hip REQUIRED CONFIG)
+    endif()
     add_compile_options(--offload-arch=${GPU_TARGET_ARCH} -x hip -Wall -Wextra -Wpedantic -Wnull-dereference)
 else()
     message(FATAL_ERROR "Invalid GPU_TARGET_ARCH '${GPU_TARGET_ARCH}'. Must start with sm_ or gfx")

--- a/README.md
+++ b/README.md
@@ -169,8 +169,9 @@ git clone https://github.com/caps-tum/mt4g.git
 cd mt4g
 mkdir build && cd build
 cmake .. -DGPU_TARGET_ARCH=<gfxXXX|sm_XX>
+# MT4G forces CMAKE_BUILD_TYPE=Release; a build type given on the command line
+# is ignored and the configure step prints "CMAKE_BUILD_TYPE is set to Release by MT4G"
 # optional build flags:
-# -DCMAKE_BUILD_TYPE=<Release|Debug>             -- to choose between release and debug builds
 # -DCMAKE_INSTALL_PREFIX=<install_prefix>        -- to set the install destination (default on UNIX platforms: /usr/local)
 make all install -j $(nproc)
 ```

--- a/README.md
+++ b/README.md
@@ -69,11 +69,11 @@ include:
 
 | _Memory Element_ | Size | Load Latency | Read & Write Bandwidth | Cache Line Size | Fetch Granularity | Amount per SM/CU or GPU | Physically Shared With |
 | ---------------- | ---- | ------------ | ---------------------- | --------------- | ----------------- | ----------------------- | ---------------------- |
-| **vL1 cache** | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ➖ |
-| **sL1d cache** | ✅ | ✅ | ❌ | ✅ | ✅ | ➖ | ✅ |
+| **vL1 cache** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ➖ |
+| **sL1d cache** | ✅ | ✅ | ✅ | ✅ | ✅ | ➖ | ✅ |
 | **L2 cache** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ➖ |
 | **L3 cache** | ✅ | ❌ | ✅ | ✅ | ❌ | ✅ | ➖ |
-| **LDS** | ✅ | ✅ | ❌ | ➖ | ➖ | ➖ | ➖ |
+| **LDS** | ✅ | ✅ | ✅ | ➖ | ➖ | ➖ | ➖ |
 | **Device Memory** | ✅ | ✅ | ✅ | ➖ | ➖ | ➖ | ➖ |
 
 #### NVIDIA
@@ -84,8 +84,8 @@ include:
 | **L2 cache** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ➖ |
 | **Texture cache** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
 | **Readonly cache** | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ | ✅ |
-| **Constant L1 cache** | ✅ | ✅ | ❌ | ✅ | ✅ | ✅ | ✅ |
-| **Constant L1.5 cache** | ✅ | ✅ | ❌ | ✅ | ✅ | ❌ | ➖ |
+| **Constant L1 cache** | ✅ | ✅ | ✅(read-only) | ✅ | ✅ | ✅ | ✅ |
+| **Constant L1.5 cache** | ✅ | ✅ | ✅(read-only) | ✅ | ✅ | ❌ | ➖ |
 | **Shared Memory** | ✅ | ✅ | ✅ | ➖ | ➖ | ➖ | ➖ |
 | **Device Memory** | ✅ | ✅ | ✅ | ➖ | ➖ | ➖ | ➖ |
 
@@ -126,6 +126,34 @@ Additionally for NVIDIA targets, the `CUDA_PATH` environment variable needs to
 be set to the CUDA installation directory.
 
 **MT4G** has been tested successfully with `hip@6.3.3` and `cuda@12.8`.
+
+#### NVIDIA targets without a ROCm installation
+
+On the NVIDIA backend, HIP is only a header layer that translates the HIP API
+into the CUDA API, and `hipcc` forwards to `nvcc`. No ROCm installation is
+needed, so a bare HIP header tree is sufficient. Point `HIP_PATH` at it, select
+the NVIDIA backend explicitly and build with `hipcc` as the C++ compiler:
+
+```bash
+export HIP_PATH=<path_to_hip>
+export CUDA_PATH=<path_to_cuda>
+export HIP_PLATFORM=nvidia
+export HIP_COMPILER=nvcc
+export HIP_RUNTIME=cuda
+export PATH=$HIP_PATH/bin:$CUDA_PATH/bin:$PATH
+
+cmake .. -DGPU_TARGET_ARCH=sm_XX -DCMAKE_CXX_COMPILER=$HIP_PATH/bin/hipcc
+```
+
+Note that `HIP_PLATFORM` alone is not enough for `hipcc`: unless `HIP_COMPILER`
+and `HIP_RUNTIME` are set as well, it still defaults to `clang`.
+
+For **CUDA 13** or newer, HIP `7.1` or later (`7.2.x` recommended) is required.
+CUDA 13 removed `cudaDeviceProp::clockRate` and `::memoryClockRate` and changed
+`cudaMemAdvise`/`cudaMemPrefetchAsync` to take a `cudaMemLocation`; only those
+HIP releases guard the affected code with `#if CUDA_VERSION >= 13000`. Older HIP
+headers fail to compile against a CUDA 13 toolkit. CUDA 13 additionally requires
+an NVIDIA driver `>= 580.65.06`.
 
 ### Build
 

--- a/src/benchmarks/bandwidth/amd_sL1ReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/amd_sL1ReadBandwidth.cpp
@@ -168,7 +168,7 @@ static std::tuple<uint64_t, double, double> sL1ReadBandwidthLauncher(size_t arra
     std::vector<uint64_t> t = util::copyFromDevice<uint64_t>(d_timings, 2);
 
     uint64_t cycles = t[1] - t[0];
-    double gpuClockHz = util::getDeviceProperties().clockRate * 1000.0;
+    double gpuClockHz = util::getClockRateKHz() * 1000.0;
     double timeS = (double)cycles / gpuClockHz;
     double dataGiB = (double)arraySizeBytes * reps / (1 * GiB);
 

--- a/src/benchmarks/bandwidth/amd_sL1WriteBandwidth.cpp
+++ b/src/benchmarks/bandwidth/amd_sL1WriteBandwidth.cpp
@@ -148,7 +148,7 @@ static std::tuple<uint64_t, double, double> sL1WriteBandwidthLauncher(size_t arr
     std::vector<uint64_t> t = util::copyFromDevice<uint64_t>(d_timings, 2);
 
     uint64_t cycles = t[1] - t[0];
-    double gpuClockHz = util::getDeviceProperties().clockRate * 1000.0;
+    double gpuClockHz = util::getClockRateKHz() * 1000.0;
     double timeS = (double)cycles / gpuClockHz;
     double dataGiB = (double)arraySizeBytes * reps / (1 * GiB);
 

--- a/src/benchmarks/bandwidth/l1ReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/l1ReadBandwidth.cpp
@@ -181,7 +181,7 @@ static std::tuple<uint64_t, double, double> l1ReadBandwidthLauncher(size_t array
     std::vector<uint64_t> timingResult = util::copyFromDevice<uint64_t>(d_timingResult, 1);
 
     // calculate the bandwidth
-    double gpuClockHz = util::getDeviceProperties().clockRate * 1000;
+    double gpuClockHz = util::getClockRateKHz() * 1000.0;
     double dataGiB = (double) arraySizeBytes * reps / (1 * GiB);
     double timeS = (double) timingResult[0] / gpuClockHz;
     

--- a/src/benchmarks/bandwidth/l1WriteBandwidth.cpp
+++ b/src/benchmarks/bandwidth/l1WriteBandwidth.cpp
@@ -171,7 +171,7 @@ static std::tuple<uint64_t, double, double> l1WriteBandwidthLauncher(size_t arra
 
     std::vector<uint64_t> timingResult = util::copyFromDevice<uint64_t>(d_timingResult, 1);
 
-    double gpuClockHz = util::getDeviceProperties().clockRate * 1000;
+    double gpuClockHz = util::getClockRateKHz() * 1000.0;
     double dataGiB = (double) arraySizeBytes * reps / (1 * GiB);
     double timeS = (double) timingResult[0] / gpuClockHz;
     

--- a/src/benchmarks/bandwidth/nvidia_readOnlyReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/nvidia_readOnlyReadBandwidth.cpp
@@ -122,7 +122,7 @@ static std::tuple<uint64_t, double, double> readOnlyReadBandwidthLauncher(size_t
     util::hipCheck(hipFree(d_timingResult));
 
     // calculate the bandwidth
-    double gpuClockHz = util::getDeviceProperties().clockRate * 1000;
+    double gpuClockHz = util::getClockRateKHz() * 1000.0;
     double dataGiB = (double) arraySizeBytes * reps / (1 * GiB);
     double timeS = (double) timingResult[0] / gpuClockHz;
 

--- a/src/benchmarks/bandwidth/nvidia_textureReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/nvidia_textureReadBandwidth.cpp
@@ -103,7 +103,7 @@ static std::tuple<uint64_t, double, double> textureReadBandwidthLauncher(size_t 
     util::hipCheck(hipFree(d_timingResult));
 
     // calculate the bandwidth
-    double gpuClockHz = util::getDeviceProperties().clockRate * 1000;
+    double gpuClockHz = util::getClockRateKHz() * 1000.0;
     double dataGiB = (double) arraySizeBytes * reps / (1 * GiB);
     double timeS = (double) timingResult[0] / gpuClockHz;
 

--- a/src/benchmarks/bandwidth/sharedReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/sharedReadBandwidth.cpp
@@ -149,7 +149,7 @@ static std::tuple<uint64_t, double, double> sharedReadBandwidthLauncher(uint32_t
 
     uint64_t cycles = t[0];
 
-    double gpuClockHz = util::getDeviceProperties().clockRate * 1000.0;
+    double gpuClockHz = util::getClockRateKHz() * 1000.0;
     double timeS = (double) cycles / gpuClockHz;
     double dataGiB = (double) arraySizeBytes  * reps / (1 * GiB);
  

--- a/src/benchmarks/bandwidth/sharedReadBandwidthStatic.cpp
+++ b/src/benchmarks/bandwidth/sharedReadBandwidthStatic.cpp
@@ -151,7 +151,7 @@ static std::tuple<uint64_t, double, double> sharedReadBandwidthStaticLauncher(ui
 
     uint64_t cycles = t[0];
 
-    double gpuClockHz = util::getDeviceProperties().clockRate * 1000.0;
+    double gpuClockHz = util::getClockRateKHz() * 1000.0;
     double timeS = (double) cycles / gpuClockHz;
     double dataGiB = (double) SIZE  * reps / (1 * GiB);
  

--- a/src/benchmarks/bandwidth/sharedWriteBandwidth.cpp
+++ b/src/benchmarks/bandwidth/sharedWriteBandwidth.cpp
@@ -138,7 +138,7 @@ static std::tuple<uint64_t, double, double> sharedWriteBandwidthLauncher(uint32_
 
     uint64_t cycles = t[0];
 
-    double gpuClockHz = util::getDeviceProperties().clockRate * 1000.0;
+    double gpuClockHz = util::getClockRateKHz() * 1000.0;
     double timeS = (double) cycles / gpuClockHz;
     double dataGiB = (double) arraySizeBytes  * reps / (1 * GiB);
  

--- a/src/benchmarks/bandwidth/sharedWriteBandwidthStatic.cpp
+++ b/src/benchmarks/bandwidth/sharedWriteBandwidthStatic.cpp
@@ -141,7 +141,7 @@ static std::tuple<uint64_t, double, double> sharedWriteBandwidthStaticLauncher(u
 
     uint64_t cycles = t[0];
 
-    double gpuClockHz = util::getDeviceProperties().clockRate * 1000.0;
+    double gpuClockHz = util::getClockRateKHz() * 1000.0;
     double timeS = (double) cycles / gpuClockHz;
     double dataGiB = (double) SIZE  * reps / (1 * GiB);
  

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -111,7 +111,7 @@ int main(int argc, char* argv[]) {
                 }},
                 {
                     "clockRate", {
-                        {"value", deviceProperties.clockRate},
+                        {"value", util::getClockRateKHz()},
                         {"unit", "kHz"}
                     },
                 },
@@ -142,7 +142,7 @@ int main(int argc, char* argv[]) {
                     "main", {
                         {
                             "memoryClockRate", {
-                                {"value", deviceProperties.memoryClockRate},
+                                {"value", util::getMemoryClockRateKHz()},
                                 {"unit", "kHz"}
                             },
                         },

--- a/src/utils/hip/device.hpp
+++ b/src/utils/hip/device.hpp
@@ -54,13 +54,28 @@ namespace util {
     }
 
     /**
+     * @brief Retrieve the memory clock rate in kHz.
+     *
+     * Queried as a device attribute rather than read from hipDeviceProp_t:
+     * CUDA 13 removed cudaDeviceProp::memoryClockRate, so HIP's NVIDIA backend
+     * leaves the corresponding hipDeviceProp_t field unwritten there.
+     */
+    inline uint32_t getMemoryClockRateKHz() {
+        int32_t device;
+        util::hipCheck(hipGetDevice(&device));
+        int32_t rateKHz;
+        util::hipCheck(hipDeviceGetAttribute(&rateKHz, hipDeviceAttributeMemoryClockRate, device));
+        return rateKHz;
+    }
+
+    /**
      * @brief Compute the theoretical peak global memory bandwidth in GiB/s.
      */
     inline double getTheoreticalMaxGlobalMemoryBandwidthGiBs() {
         static double bwGiBs = []() -> double {
-            hipDeviceProp_t prop;
+            hipDeviceProp_t prop{};
             hipCheck(hipGetDeviceProperties(&prop, 0));
-            double clkMHz = static_cast<double>(prop.memoryClockRate) / 1000.0;
+            double clkMHz = static_cast<double>(getMemoryClockRateKHz()) / 1000.0;
             double busBytes = static_cast<double>(prop.memoryBusWidth) / 8.0;
             double bytesPerSec = clkMHz * 1e6 * busBytes * 2.0;
             return bytesPerSec / (1024.0 * 1024.0 * 1024.0);
@@ -250,6 +265,9 @@ namespace util {
 
     /**
      * @brief Retrieve the GPU core clock rate in kHz.
+     *
+     * Queried as a device attribute for the same reason as
+     * getMemoryClockRateKHz(): CUDA 13 removed cudaDeviceProp::clockRate.
      */
     inline uint32_t getClockRateKHz() {
         int32_t device;

--- a/src/utils/hip/runtime.hpp
+++ b/src/utils/hip/runtime.hpp
@@ -77,7 +77,7 @@ namespace util {
         static hipDeviceProp_t deviceProperties = []() {
             int device;
             util::hipCheck(hipGetDevice(&device));
-            hipDeviceProp_t props;
+            hipDeviceProp_t props{};
             util::hipCheck(hipGetDeviceProperties(&props, device));
             return props;
         }();


### PR DESCRIPTION
- mt4g now always builds with CMAKE_BUILD_TYPE=Release, and the README no longer asks users to choose a build type
- the compiler flags differ between the platforms:
      - on NVIDIA, the build type doesn't affect device code generation
      - on AMD, unoptimized (-O0) builds fail to compile due to AMD GPU backend errors. Release therefore provides a
         consistent, working configuration across platforms
- the experiments also showed no relevant result differences between explicit Release and forced Release builds

- during the AMD tests, I found another seperate issue: l2ReadBandwidth.cpp hardcodes the sc1 modifier instead of using the GLC macro, which prevents gfx90a builds, so I fixed it