### PR TITLE
Fix getNumXCDs()

### DIFF
--- a/src/utils/hip/device.hpp
+++ b/src/utils/hip/device.hpp
@@ -204,22 +204,19 @@ namespace util {
     }
 
     /**
-     * @brief Query how many XCDs (dies) the GPU comprises.
+     * @brief Query how many XCDs back the currently selected logical GPU.
      */
     inline uint32_t getNumXCDs() {
-        static uint32_t xcdCount = [](){
-            #ifdef __HIP_PLATFORM_NVIDIA__
-            return 1;
-            #endif
-            #ifdef __HIP_PLATFORM_AMD__
-            util::rocmCheck(rsmi_init(0));
-            int device;
-            util::hipCheck(hipGetDevice(&device));
-            uint16_t xcdCounter;
-            util::rocmCheck(rsmi_dev_metrics_xcd_counter_get(device, &xcdCounter));
-            return static_cast<uint32_t>(xcdCounter);
-            #endif
+        static const uint32_t xcdCount = []() {
+    #ifdef __HIP_PLATFORM_NVIDIA__
+            return 1u;
+    #elif defined(__HIP_PLATFORM_AMD__)
+            return getNumXccFromKfd().value_or(1u);
+    #else
+            return 1u;
+    #endif
         }();
+    
         return xcdCount;
     }
 

--- a/src/utils/hip/hsa.hpp
+++ b/src/utils/hip/hsa.hpp
@@ -152,5 +152,26 @@ inline std::optional<size_t> getKfdCacheAmountForLevel(uint32_t level) {
     if (count == 0) return std::nullopt;
     return count;
 }
+
+inline std::optional<uint32_t> getNumXccFromKfd() {
+    hsa_agent_t agent = getCurrentHsaAgent();
+    if (!agent.handle) return std::nullopt;
+    uint32_t node = 0;
+    if (hsa_agent_get_info(agent,
+          (hsa_agent_info_t)HSA_AMD_AGENT_INFO_DRIVER_NODE_ID, &node) != HSA_STATUS_SUCCESS)
+        return std::nullopt;
+    const std::string prop_path =
+        "/sys/class/kfd/kfd/topology/nodes/" + std::to_string(node) + "/properties";
+    std::ifstream f(prop_path);
+    if (!f) return std::nullopt;
+    std::string key, val;
+    while (f >> key >> val) {
+        if (key == "num_xcc") {
+            int n = std::stoi(val);
+            if (n > 0) return static_cast<uint32_t>(n);
+        }
+    }
+    return std::nullopt;
+}
 #endif
 


### PR DESCRIPTION
## Description

This PR changes how MT4G determines the number of XCDs/XCCs backing the currently selected logical AMD GPU.

The previous implementation used `rsmi_dev_metrics_xcd_counter_get()` from ROCm SMI. On the tested MI300A system, this metric was unavailable or did not provide the required logical-partition topology information. Because the query was wrapped in `rocmCheck()`, an unsupported metric prevented MT4G from running.

The new implementation obtains the KFD topology node associated with the current HSA GPU agent and reads its `num_xcc` property from sysfs.

## Previous behavior

```cpp
util::rocmCheck(rsmi_init(0));

int device;
util::hipCheck(hipGetDevice(&device));

uint16_t xcdCounter;
util::rocmCheck(
    rsmi_dev_metrics_xcd_counter_get(device, &xcdCounter)
);

return static_cast<uint32_t>(xcdCounter);
```

## New behavior

The new `getNumXccFromKfd()` helper:

1. Retrieves the current HSA GPU agent.
2. Queries `HSA_AMD_AGENT_INFO_DRIVER_NODE_ID` to identify its KFD topology node.
3. Opens `/sys/class/kfd/kfd/topology/nodes/<node>/properties`.
4. Reads and validates the `num_xcc` property.
5. Returns `std::nullopt` if the agent, node ID, topology file, or property is unavailable.

`getNumXCDs()` now uses this value for AMD devices:

```cpp
/**
 * @brief Query how many XCDs back the currently selected logical GPU.
 */
inline uint32_t getNumXCDs() {
    static const uint32_t xcdCount = []() {
#ifdef __HIP_PLATFORM_NVIDIA__
        return 1u;
#elif defined(__HIP_PLATFORM_AMD__)
        return getNumXccFromKfd().value_or(1u);
#else
        return 1u;
#endif
    }();

    return xcdCount;
}
```

NVIDIA devices continue to return `1`. AMD devices also fall back to `1` when the KFD topology information is unavailable, allowing MT4G to continue instead of terminating because of an unsupported ROCm SMI metric.

The value is cached on first use because MT4G selects one logical GPU for a run and does not normally switch devices afterward.

## Why this is needed for MI300A partitioning

MI300A compute partitioning changes the logical GPU agents exposed by ROCm. The relevant value is therefore the number of XCCs backing the selected logical GPU partition, rather than only a package-level value.

The collected KFD topology reports the expected relationship between logical
GPU agents and XCCs in every tested compute-partition mode:

| Mode | Logical GPU agents | `num_xcc` per agent | Total XCCs |
| --- | ---: | ---: | ---: |
| SPX | 2 | 6 | 12 |
| TPX | 6 | 2 | 12 |
| CPX | 12 | 1 | 12 |

Reading the property through the current HSA agent ensures that MT4G selects the KFD node corresponding to the logical device being benchmarked.

The function documentation was updated to clarify that the result describes the selected logical GPU, not necessarily the total number of physical dies in the complete GPU package.

## Compatibility and limitations

- NVIDIA behavior is unchanged and returns `1`.
- AMD GPUs whose KFD topology exposes `num_xcc` use the reported value.
- AMD systems without the property fall back to `1` instead of failing.
- The change was validated on MI300A in SPX, TPX, and CPX compute-partition modes.
- Older AMD GPUs and other kernel/ROCm combinations require separate validation before claiming complete platform coverage.

The fallback preserves execution on unsupported systems, but it may conservatively report `1` for a multi-XCC logical GPU when its kernel does not expose `num_xcc`.

## Validation

The collected MI300A KFD topology snapshots showed:

- SPX: 2 logical GPU agents with 912 SIMD entries and `num_xcc 6` per agent.
- TPX: 6 logical GPU agents with 304 SIMD entries and `num_xcc 2` per agent.
- CPX: 12 logical GPU agents with 152 SIMD entries and `num_xcc 1` per agent.

In every mode, the logical-agent count multiplied by `num_xcc` accounts for
all 12 XCCs. The corresponding SIMD totals are also consistent: each XCC
contributes 152 SIMD entries. This confirms that the KFD property describes the
number of XCCs backing the selected logical GPU partition across all three
tested partition modes.
