### PR TITLE
Enforce Release build type

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ endif()
 
 project(mt4g VERSION 1.2.0 LANGUAGES ${MT4G_LANGUAGES})
 
+# MT4G is always built optimized; FORCE also overrides a command-line build type.
+set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type (forced by MT4G)" FORCE)
+message(STATUS "CMAKE_BUILD_TYPE is set to Release by MT4G")
+
 find_package(nlohmann_json 3.11.2 REQUIRED)
 find_package(cxxopts 3.2.0 REQUIRED)
 

--- a/README.md
+++ b/README.md
@@ -141,8 +141,10 @@ git clone https://github.com/caps-tum/mt4g.git
 cd mt4g
 mkdir build && cd build
 cmake .. -DGPU_TARGET_ARCH=<gfxXXX|sm_XX>
+# MT4G forces CMAKE_BUILD_TYPE=Release; a build type given on the command line
+# is ignored and the configure step prints
+# "CMAKE_BUILD_TYPE is set to Release by MT4G"
 # optional build flags:
-# -DCMAKE_BUILD_TYPE=<Release|Debug>             -- to choose between release and debug builds
 # -DCMAKE_INSTALL_PREFIX=<install_prefix>        -- to set the install destination (default on UNIX platforms: /usr/local)
 make all install -j $(nproc)
 ```


### PR DESCRIPTION
CMake defines the following compiler flag sets:
- No build type: no additional flags
- Debug: -g
- Release:** -O3 -DNDEBUG

I crossed these three flag sets with the three build types, which results in the following 9 configurations:
Build type x compiler flags = resulting configuration (exact flags), of course -g -g is simply -g
None x no flags = None
Debug x no flags = -g
Release x no flags = -O3 -DNDEBUG
None x -g = -g
Debug x -g = -g -g
Release x -g = -g -O3 -DNDEBUG
None x -03 -DNDEBUG = -O3 -DNDEBUG
Debug x -g = -g -O3 -DNDEBUG
Release x -O3 -DNDEBUG = -O3 -DNDEBUG -O3 -DNDEBUG

I use (Release x no flags = -03 -DNDEBUG) as the BASELINE and compare all other configurations to it. Another important thing to note is that hipcc unconditionally adds -O3 to both the host (CPU) and device (GPU) compilation. So even the no-build-type and Debug configurations produce optimized code. Debug additionally enables debug information.

NVIDIA (narq1 - H00)
Compared to the baseline (Release x no flags), there was no meaningful difference in the other 8 configurations in terms of runtime or MT4G results, just noise. Also, all configurations produced byte-identical GPU device code (this I let AI check).

AMD (milan1 - MI210 CDNA2)
Even here there was no statistically significant difference in runtime or MT4G results. Earlier no-build-type and Debug was failing because the amdclang++ compiler was used, which does not add the -O3 compiler flag, but now hipcc unconditionally adds -O3, so all build types succeed. Here configurations are byte-identical binaries (up to 3.96%, once again I used AI to check this).

=> There is no measurable performance difference between the different build configurations on either NVIDIA or AMD, so we can safely set CMAKE_BUILD_TYPE=Release as the default build type for MT4G.