### PR TITLE
Enforce Release build type and update hipDeviceGetAttribute() implemenatation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,6 +21,10 @@ endif()
 
 project(mt4g VERSION 1.2.0 LANGUAGES ${MT4G_LANGUAGES})
 
+# MT4G is always built optimized; FORCE also overrides a command-line build type.
+set(CMAKE_BUILD_TYPE Release CACHE STRING "Build type (forced by MT4G)" FORCE)
+message(STATUS "CMAKE_BUILD_TYPE is set to Release by MT4G")
+
 find_package(nlohmann_json 3.11.2 REQUIRED)
 find_package(cxxopts 3.2.0 REQUIRED)
 

--- a/README.md
+++ b/README.md
@@ -141,8 +141,10 @@ git clone https://github.com/caps-tum/mt4g.git
 cd mt4g
 mkdir build && cd build
 cmake .. -DGPU_TARGET_ARCH=<gfxXXX|sm_XX>
+# MT4G forces CMAKE_BUILD_TYPE=Release; a build type given on the command line
+# is ignored and the configure step prints
+# "CMAKE_BUILD_TYPE is set to Release by MT4G"
 # optional build flags:
-# -DCMAKE_BUILD_TYPE=<Release|Debug>             -- to choose between release and debug builds
 # -DCMAKE_INSTALL_PREFIX=<install_prefix>        -- to set the install destination (default on UNIX platforms: /usr/local)
 make all install -j $(nproc)
 ```

--- a/src/benchmarks/bandwidth/amd_l1ReadBandwidthBlocksweep.cpp
+++ b/src/benchmarks/bandwidth/amd_l1ReadBandwidthBlocksweep.cpp
@@ -89,10 +89,10 @@ namespace benchmark
             // pin the entire sweep to a single CU.
             auto stream = util::createStreamForCU(0);
 
-            uint32_t minThreads = util::getDeviceProperties().warpSize;
-            uint32_t maxThreads = util::getDeviceProperties().maxThreadsPerBlock;
+            uint32_t minThreads = util::getWarpSize();
+            uint32_t maxThreads = util::getMaxThreadsPerBlock();
             uint32_t minBlocks = 1;
-            uint32_t maxBlocks = util::getDeviceProperties().maxBlocksPerMultiProcessor;
+            uint32_t maxBlocks = util::getMaxBlocksPerMultiProcessor();
             
             size_t minReps = MIN_REPS;
             size_t maxReps = MAX_REPS;

--- a/src/benchmarks/bandwidth/amd_l1WriteBandwidthBlocksweep.cpp
+++ b/src/benchmarks/bandwidth/amd_l1WriteBandwidthBlocksweep.cpp
@@ -81,10 +81,10 @@ namespace benchmark {
             // pin the entire sweep to a single CU.
             auto stream = util::createStreamForCU(0);
 
-            uint32_t minThreads = util::getDeviceProperties().warpSize;
-            uint32_t maxThreads = util::getDeviceProperties().maxThreadsPerBlock;
+            uint32_t minThreads = util::getWarpSize();
+            uint32_t maxThreads = util::getMaxThreadsPerBlock();
             uint32_t minBlocks = 1;
-            uint32_t maxBlocks = util::getDeviceProperties().maxBlocksPerMultiProcessor;
+            uint32_t maxBlocks = util::getMaxBlocksPerMultiProcessor();
             
             size_t minReps = MIN_REPS;
             size_t maxReps = MAX_REPS;

--- a/src/benchmarks/bandwidth/amd_l3ReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/amd_l3ReadBandwidth.cpp
@@ -77,8 +77,8 @@ namespace benchmark {
             util::hipDeviceReset();
 
             const size_t arraySizeBytes = util::max(l2SizeBytes * (util::getNumXCDs() + 2), l3SizeBytes / 4);
-            uint32_t maxThreads = util::getDeviceProperties().maxThreadsPerBlock;
-            uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getDeviceProperties().maxBlocksPerMultiProcessor;
+            uint32_t maxThreads = util::getMaxThreadsPerBlock();
+            uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getMaxBlocksPerMultiProcessor();
             size_t maxReps = MAX_REPS / 4;
 
             std::vector<double> results(ROUNDS);
@@ -96,11 +96,11 @@ namespace benchmark {
 
             size_t arraySizeBytes = util::max(l2SizeBytes * (util::getNumXCDs() + 2), l3SizeBytes / 4);
 
-            uint32_t minThreads = util::getDeviceProperties().warpSize;
-            uint32_t maxThreads = util::getDeviceProperties().maxThreadsPerBlock;
+            uint32_t minThreads = util::getWarpSize();
+            uint32_t maxThreads = util::getMaxThreadsPerBlock();
 
             uint32_t minBlocks = util::getNumberOfComputeUnits();
-            uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getDeviceProperties().maxBlocksPerMultiProcessor;
+            uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getMaxBlocksPerMultiProcessor();
 
             size_t minReps = MIN_REPS;
             size_t maxReps = MAX_REPS;

--- a/src/benchmarks/bandwidth/amd_l3WriteBandwidth.cpp
+++ b/src/benchmarks/bandwidth/amd_l3WriteBandwidth.cpp
@@ -74,8 +74,8 @@ namespace benchmark {
             util::hipDeviceReset();
 
             const size_t arraySizeBytes = util::max(l2SizeBytes * (util::getNumXCDs() + 2), l3SizeBytes / 4);
-            uint32_t maxThreads = util::getDeviceProperties().maxThreadsPerBlock;
-            uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getDeviceProperties().maxBlocksPerMultiProcessor;
+            uint32_t maxThreads = util::getMaxThreadsPerBlock();
+            uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getMaxBlocksPerMultiProcessor();
             size_t maxReps = MAX_REPS / 4;
 
             std::vector<double> results(ROUNDS);
@@ -93,11 +93,11 @@ namespace benchmark {
 
             size_t arraySizeBytes = util::max(l2SizeBytes * (util::getNumXCDs() + 2), l3SizeBytes / 4);
 
-            uint32_t minThreads = util::getDeviceProperties().warpSize;
-            uint32_t maxThreads = util::getDeviceProperties().maxThreadsPerBlock;
+            uint32_t minThreads = util::getWarpSize();
+            uint32_t maxThreads = util::getMaxThreadsPerBlock();
 
             uint32_t minBlocks = util::getNumberOfComputeUnits();
-            uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getDeviceProperties().maxBlocksPerMultiProcessor;
+            uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getMaxBlocksPerMultiProcessor();
 
             size_t minReps = MIN_REPS;
             size_t maxReps = MAX_REPS;

--- a/src/benchmarks/bandwidth/amd_sL1ReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/amd_sL1ReadBandwidth.cpp
@@ -155,7 +155,7 @@ __global__ void sL1ReadBandwidthKernel(uint32_t* __restrict__ dst, uint32v16* __
 static std::tuple<uint64_t, double, double> sL1ReadBandwidthLauncher(size_t arraySizeBytes, uint32_t numThreads, size_t reps) 
 {
     size_t numElements = arraySizeBytes / sizeof(uint32v16);
-    uint32_t waveSize = util::getDeviceProperties().warpSize;
+    uint32_t waveSize = util::getWarpSize();
     uint32_t numWaves = numThreads / waveSize;
     size_t elementsPerWave = numElements / numWaves;
     
@@ -181,7 +181,7 @@ namespace benchmark {
         {
             std::vector<double> results(ROUNDS);
 
-            uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+            uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
             size_t maxReps = MAX_REPS;
 
             for (uint32_t i = 0; i < ROUNDS; ++i) 
@@ -194,8 +194,8 @@ namespace benchmark {
 
         CacheBandwidthResult measureScalarL1ReadBandwidthSweep(size_t arraySizeBytes) 
         {
-            uint32_t minNumThreads = util::getDeviceProperties().warpSize;
-            uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+            uint32_t minNumThreads = util::getWarpSize();
+            uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
             size_t minReps = MIN_REPS;
             size_t maxReps = MAX_REPS;
 

--- a/src/benchmarks/bandwidth/amd_sL1WriteBandwidth.cpp
+++ b/src/benchmarks/bandwidth/amd_sL1WriteBandwidth.cpp
@@ -136,7 +136,7 @@ __global__ void sL1WriteBandwidthKernel(uint32v4* __restrict__ dst, uint64_t* __
 static std::tuple<uint64_t, double, double> sL1WriteBandwidthLauncher(size_t arraySizeBytes, uint32_t numThreads, size_t reps) 
 {
     size_t numElements = arraySizeBytes / sizeof(uint32v4);
-    uint32_t waveSize = util::getDeviceProperties().warpSize;
+    uint32_t waveSize = util::getWarpSize();
     uint32_t numWaves = numThreads / waveSize;
     size_t elementsPerWave = numElements / numWaves;
     
@@ -161,7 +161,7 @@ namespace benchmark {
         {
             std::vector<double> results(ROUNDS);
 
-            uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+            uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
             size_t maxReps = MAX_REPS;
 
             for (uint32_t i = 0; i < ROUNDS; ++i) 
@@ -174,8 +174,8 @@ namespace benchmark {
 
         CacheBandwidthResult measureScalarL1WriteBandwidthSweep(size_t arraySizeBytes) 
         {            
-            uint32_t minNumThreads = util::getDeviceProperties().warpSize;
-            uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+            uint32_t minNumThreads = util::getWarpSize();
+            uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
             size_t minReps = MIN_REPS;
             size_t maxReps = MAX_REPS;
 

--- a/src/benchmarks/bandwidth/l1ReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/l1ReadBandwidth.cpp
@@ -196,7 +196,7 @@ namespace benchmark
     {
         std::vector<double> results(ROUNDS);
 
-        uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
         size_t maxReps = MAX_REPS;
 
         for (uint32_t i = 0; i < ROUNDS; ++i) 
@@ -209,8 +209,8 @@ namespace benchmark
 
     CacheBandwidthResult measureL1ReadBandwidthSweep(size_t arraySizeBytes) 
     {
-        uint32_t minNumThreads = util::getDeviceProperties().warpSize;
-        uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t minNumThreads = util::getWarpSize();
+        uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
         size_t minReps = MIN_REPS;
         size_t maxReps = MAX_REPS;
 

--- a/src/benchmarks/bandwidth/l1WriteBandwidth.cpp
+++ b/src/benchmarks/bandwidth/l1WriteBandwidth.cpp
@@ -186,7 +186,7 @@ namespace benchmark
     {
         std::vector<double> results(ROUNDS);
 
-        uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
         size_t maxReps = MAX_REPS;
 
         for (uint32_t i = 0; i < ROUNDS; ++i) 
@@ -199,8 +199,8 @@ namespace benchmark
 
     CacheBandwidthResult measureL1WriteBandwidthSweep(size_t arraySizeBytes) 
     {
-        uint32_t minNumThreads = util::getDeviceProperties().warpSize;
-        uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t minNumThreads = util::getWarpSize();
+        uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
         size_t minReps = MIN_REPS;
         size_t maxReps = MAX_REPS;
 

--- a/src/benchmarks/bandwidth/l2ReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/l2ReadBandwidth.cpp
@@ -101,8 +101,8 @@ namespace benchmark {
         util::hipDeviceReset();
 
         const size_t arraySizeBytes = l2SizeBytes * 0.8; // 80% L2 size, L1 is bypassed
-        uint32_t maxThreads = util::getDeviceProperties().maxThreadsPerBlock;
-        uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getDeviceProperties().maxBlocksPerMultiProcessor;
+        uint32_t maxThreads = util::getMaxThreadsPerBlock();
+        uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getMaxBlocksPerMultiProcessor();
         size_t maxReps = MAX_REPS / 4;
 
         std::vector<double> results(ROUNDS);
@@ -120,11 +120,11 @@ namespace benchmark {
 
         const size_t arraySizeBytes = l2SizeBytes * 0.8; // 80% L2 size, L1 is bypassed
 
-        uint32_t minThreads = util::getDeviceProperties().warpSize;
-        uint32_t maxThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t minThreads = util::getWarpSize();
+        uint32_t maxThreads = util::getMaxThreadsPerBlock();
 
         uint32_t minBlocks = util::getNumberOfComputeUnits();
-        uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getDeviceProperties().maxBlocksPerMultiProcessor;
+        uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getMaxBlocksPerMultiProcessor();
 
         size_t minReps = MIN_REPS;
         size_t maxReps = MAX_REPS;

--- a/src/benchmarks/bandwidth/l2WriteBandwidth.cpp
+++ b/src/benchmarks/bandwidth/l2WriteBandwidth.cpp
@@ -87,8 +87,8 @@ namespace benchmark {
         util::hipDeviceReset();
 
         const size_t arraySizeBytes = l2SizeBytes * 0.8; // 80% L2 size, L1 is bypassed
-        uint32_t maxThreads = util::getDeviceProperties().maxThreadsPerBlock;
-        uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getDeviceProperties().maxBlocksPerMultiProcessor;
+        uint32_t maxThreads = util::getMaxThreadsPerBlock();
+        uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getMaxBlocksPerMultiProcessor();
         size_t maxReps = MAX_REPS / 4;
 
         std::vector<double> results(ROUNDS);
@@ -106,11 +106,11 @@ namespace benchmark {
 
         const size_t arraySizeBytes = l2SizeBytes * 0.8; // 80% L2 size, L1 is bypassed
 
-        uint32_t minThreads = util::getDeviceProperties().warpSize;
-        uint32_t maxThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t minThreads = util::getWarpSize();
+        uint32_t maxThreads = util::getMaxThreadsPerBlock();
 
         uint32_t minBlocks = util::getNumberOfComputeUnits();
-        uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getDeviceProperties().maxBlocksPerMultiProcessor;
+        uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getMaxBlocksPerMultiProcessor();
 
         size_t minReps = MIN_REPS;
         size_t maxReps = MAX_REPS;

--- a/src/benchmarks/bandwidth/mainMemoryReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/mainMemoryReadBandwidth.cpp
@@ -53,7 +53,7 @@ double mainMemoryReadBandwidthLauncher(size_t arraySizeBytes) {
     util::hipDeviceReset(); 
 
     uint32_t maxThreadsPerBlock = util::min(util::getMaxThreadsPerBlock(), util::getWarpSize() * util::getSIMDsPerCU()); 
-    uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getDeviceProperties().maxBlocksPerMultiProcessor;
+    uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getMaxBlocksPerMultiProcessor();
 
     // Initialize device Arrays
     // sizeof(uint32v4) = 16 bytes -> allows us to load 4 integers with one instruction -> probability 
@@ -165,11 +165,11 @@ namespace benchmark {
         // over-reports bandwidth, so main memory uses one pass over a ~1 GiB set.
         size_t arraySizeBytes = util::min(mainMemorySizeBytes / SIZE_DOWN, static_cast<size_t>(1) * 1024 * 1024 * 1024);
 
-        uint32_t minThreads = util::getDeviceProperties().warpSize;
-        uint32_t maxThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t minThreads = util::getWarpSize();
+        uint32_t maxThreads = util::getMaxThreadsPerBlock();
 
         uint32_t minBlocks = util::getNumberOfComputeUnits();
-        uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getDeviceProperties().maxBlocksPerMultiProcessor;
+        uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getMaxBlocksPerMultiProcessor();
 
         CacheBandwidthResult result{};
         result.measuredBandwidth = 0.0;

--- a/src/benchmarks/bandwidth/mainMemoryWriteBandwidth.cpp
+++ b/src/benchmarks/bandwidth/mainMemoryWriteBandwidth.cpp
@@ -48,7 +48,7 @@ double mainMemoryWriteBandwidthLauncher(size_t arraySizeBytes) {
     util::hipDeviceReset(); 
 
     uint32_t maxThreadsPerBlock = util::min(util::getMaxThreadsPerBlock(), util::getWarpSize() * util::getSIMDsPerCU()); 
-    uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getDeviceProperties().maxBlocksPerMultiProcessor;
+    uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getMaxBlocksPerMultiProcessor();
 
     uint32v4 *d_dstArr = util::allocateGPUMemory<uint32v4>(arraySizeBytes / sizeof(uint32v4));
     
@@ -150,11 +150,11 @@ namespace benchmark {
         // over-reports bandwidth, so main memory uses one pass over a ~1 GiB set.
         size_t arraySizeBytes = util::min(mainMemorySizeBytes / SIZE_DOWN, static_cast<size_t>(1) * 1024 * 1024 * 1024);
 
-        uint32_t minThreads = util::getDeviceProperties().warpSize;
-        uint32_t maxThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t minThreads = util::getWarpSize();
+        uint32_t maxThreads = util::getMaxThreadsPerBlock();
 
         uint32_t minBlocks = util::getNumberOfComputeUnits();
-        uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getDeviceProperties().maxBlocksPerMultiProcessor;
+        uint32_t maxBlocks = util::getNumberOfComputeUnits() * util::getMaxBlocksPerMultiProcessor();
 
         CacheBandwidthResult result{};
         result.measuredBandwidth = 0.0;

--- a/src/benchmarks/bandwidth/nvidia_constantL15ReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/nvidia_constantL15ReadBandwidth.cpp
@@ -139,7 +139,7 @@ static std::tuple<uint64_t, double, double> constantL15ReadBandwidthLauncher(siz
 
     // Constant working sets are small, so integer division can leave bytes untouched.
     // Count only the bytes actually read, not the full cache lines fetched by the stride.
-    double gpuClockHz = util::getDeviceProperties().clockRate * 1000;
+    double gpuClockHz = util::getClockRateKHz() * 1000.0;
     double dataGiB = (double) (elementsPerThread * numThreads * sizeof(uint32_t)) * reps / (1 * GiB);
     double timeS = (double) timingResult[0] / gpuClockHz;
 
@@ -178,7 +178,7 @@ static size_t capStride(size_t strideBytes)
 static uint32_t capNumThreads(size_t arraySizeBytes, size_t strideBytes)
 {
     size_t lines = (arraySizeBytes / sizeof(uint32_t)) / (strideBytes / sizeof(uint32_t));
-    uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+    uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
 
     return static_cast<uint32_t>(std::min(static_cast<size_t>(maxNumThreads), lines));
 }
@@ -216,7 +216,7 @@ namespace benchmark
             arraySizeBytes = capConstantArraySize(arraySizeBytes);
             size_t strideBytes = capStride(constantFetchGranularityBytes);
 
-            uint32_t minNumThreads = util::getDeviceProperties().warpSize;
+            uint32_t minNumThreads = util::getWarpSize();
             uint32_t maxNumThreads = capNumThreads(arraySizeBytes, strideBytes);
             size_t minReps = MIN_REPS;
             size_t maxReps = MAX_REPS;

--- a/src/benchmarks/bandwidth/nvidia_constantL1ReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/nvidia_constantL1ReadBandwidth.cpp
@@ -128,7 +128,7 @@ static std::tuple<uint64_t, double, double> constantL1ReadBandwidthLauncher(size
 
     // Constant working sets are small, so integer division can leave bytes untouched.
     // Use the bytes actually read rather than the requested array size.
-    double gpuClockHz = util::getDeviceProperties().clockRate * 1000;
+    double gpuClockHz = util::getClockRateKHz() * 1000.0;
     double dataGiB = (double) (elementsPerThread * numThreads * sizeof(uint32_t)) * reps / (1 * GiB);
     double timeS = (double) timingResult[0] / gpuClockHz;
 
@@ -153,7 +153,7 @@ static size_t capConstantArraySize(size_t arraySizeBytes, const char* benchmarkN
 static uint32_t capNumThreads(size_t arraySizeBytes)
 {
     size_t totalElements = arraySizeBytes / sizeof(uint32_t);
-    uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+    uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
 
     return static_cast<uint32_t>(std::min(static_cast<size_t>(maxNumThreads), totalElements));
 }
@@ -189,7 +189,7 @@ namespace benchmark
         {
             arraySizeBytes = capConstantArraySize(arraySizeBytes, "Constant L1 Read Bandwidth");
 
-            uint32_t minNumThreads = util::getDeviceProperties().warpSize;
+            uint32_t minNumThreads = util::getWarpSize();
             uint32_t maxNumThreads = capNumThreads(arraySizeBytes);
             size_t minReps = MIN_REPS;
             size_t maxReps = MAX_REPS;

--- a/src/benchmarks/bandwidth/nvidia_readOnlyReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/nvidia_readOnlyReadBandwidth.cpp
@@ -139,7 +139,7 @@ namespace benchmark
         {
             std::vector<double> results(ROUNDS);
 
-            uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+            uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
             size_t maxReps = MAX_REPS;
 
             for (uint32_t i = 0; i < ROUNDS; ++i)
@@ -152,8 +152,8 @@ namespace benchmark
 
         CacheBandwidthResult measureReadOnlyReadBandwidthSweep(size_t arraySizeBytes)
         {
-            uint32_t minNumThreads = util::getDeviceProperties().warpSize;
-            uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+            uint32_t minNumThreads = util::getWarpSize();
+            uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
             size_t minReps = MIN_REPS;
             size_t maxReps = MAX_REPS;
 

--- a/src/benchmarks/bandwidth/nvidia_textureReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/nvidia_textureReadBandwidth.cpp
@@ -120,7 +120,7 @@ namespace benchmark
         {
             std::vector<double> results(ROUNDS);
 
-            uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+            uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
             size_t maxReps = MAX_REPS;
 
             for (uint32_t i = 0; i < ROUNDS; ++i)
@@ -133,8 +133,8 @@ namespace benchmark
 
         CacheBandwidthResult measureTextureReadBandwidthSweep(size_t arraySizeBytes)
         {
-            uint32_t minNumThreads = util::getDeviceProperties().warpSize;
-            uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+            uint32_t minNumThreads = util::getWarpSize();
+            uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
             size_t minReps = MIN_REPS;
             size_t maxReps = MAX_REPS;
 

--- a/src/benchmarks/bandwidth/sharedReadBandwidth.cpp
+++ b/src/benchmarks/bandwidth/sharedReadBandwidth.cpp
@@ -162,7 +162,7 @@ namespace benchmark
     {
         std::vector<double> results(ROUNDS);
 
-        uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
         size_t maxReps = MAX_REPS;
 
         for (uint32_t i = 0; i < ROUNDS; ++i) 
@@ -175,8 +175,8 @@ namespace benchmark
 
     CacheBandwidthResult measureSharedReadBandwidthSweep(uint32_t arraySizeBytes) 
     {
-        uint32_t minNumThreads = util::getDeviceProperties().warpSize;
-        uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t minNumThreads = util::getWarpSize();
+        uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
         size_t minReps = MIN_REPS;
         size_t maxReps = MAX_REPS;
 

--- a/src/benchmarks/bandwidth/sharedReadBandwidthStatic.cpp
+++ b/src/benchmarks/bandwidth/sharedReadBandwidthStatic.cpp
@@ -164,7 +164,7 @@ namespace benchmark
     {
         std::vector<double> results(ROUNDS);
 
-        uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
         size_t maxReps = MAX_REPS;
 
         for (uint32_t i = 0; i < ROUNDS; ++i) 
@@ -177,8 +177,8 @@ namespace benchmark
 
     CacheBandwidthResult measureSharedReadBandwidthStaticSweep() 
     {
-        uint32_t minNumThreads = util::getDeviceProperties().warpSize;
-        uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t minNumThreads = util::getWarpSize();
+        uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
         size_t minReps = MIN_REPS;
         size_t maxReps = MAX_REPS;
 

--- a/src/benchmarks/bandwidth/sharedWriteBandwidth.cpp
+++ b/src/benchmarks/bandwidth/sharedWriteBandwidth.cpp
@@ -150,7 +150,7 @@ namespace benchmark {
     {
         std::vector<double> results(ROUNDS);
 
-        uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
         size_t maxReps = MAX_REPS;
 
         for (uint32_t i = 0; i < ROUNDS; ++i) 
@@ -163,8 +163,8 @@ namespace benchmark {
 
     CacheBandwidthResult measureSharedWriteBandwidthSweep(uint32_t arraySizeBytes) 
     {
-        uint32_t minNumThreads = util::getDeviceProperties().warpSize;
-        uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t minNumThreads = util::getWarpSize();
+        uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
         size_t minReps = MIN_REPS;
         size_t maxReps = MAX_REPS;
 

--- a/src/benchmarks/bandwidth/sharedWriteBandwidthStatic.cpp
+++ b/src/benchmarks/bandwidth/sharedWriteBandwidthStatic.cpp
@@ -153,7 +153,7 @@ namespace benchmark {
     {
         std::vector<double> results(ROUNDS);
 
-        uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
         size_t maxReps = MAX_REPS;
 
         for (uint32_t i = 0; i < ROUNDS; ++i) 
@@ -166,8 +166,8 @@ namespace benchmark {
 
     CacheBandwidthResult measureSharedWriteBandwidthStaticSweep() 
     {
-        uint32_t minNumThreads = util::getDeviceProperties().warpSize;
-        uint32_t maxNumThreads = util::getDeviceProperties().maxThreadsPerBlock;
+        uint32_t minNumThreads = util::getWarpSize();
+        uint32_t maxNumThreads = util::getMaxThreadsPerBlock();
         size_t minReps = MIN_REPS;
         size_t maxReps = MAX_REPS;
 

--- a/src/utils/hip/device.hpp
+++ b/src/utils/hip/device.hpp
@@ -54,6 +54,17 @@ namespace util {
     }
 
     /**
+     * @brief Query a single attribute of the current device.
+     */
+    inline int32_t getDeviceAttribute(hipDeviceAttribute_t attribute) {
+        int32_t device;
+        util::hipCheck(hipGetDevice(&device));
+        int32_t value;
+        util::hipCheck(hipDeviceGetAttribute(&value, attribute, device));
+        return value;
+    }
+
+    /**
      * @brief Retrieve the memory clock rate in kHz.
      *
      * Queried as a device attribute rather than read from hipDeviceProp_t:
@@ -61,10 +72,7 @@ namespace util {
      * leaves the corresponding hipDeviceProp_t field unwritten there.
      */
     inline uint32_t getMemoryClockRateKHz() {
-        int32_t device;
-        util::hipCheck(hipGetDevice(&device));
-        int32_t rateKHz;
-        util::hipCheck(hipDeviceGetAttribute(&rateKHz, hipDeviceAttributeMemoryClockRate, device));
+        static uint32_t rateKHz = static_cast<uint32_t>(getDeviceAttribute(hipDeviceAttributeMemoryClockRate));
         return rateKHz;
     }
 
@@ -73,10 +81,8 @@ namespace util {
      */
     inline double getTheoreticalMaxGlobalMemoryBandwidthGiBs() {
         static double bwGiBs = []() -> double {
-            hipDeviceProp_t prop{};
-            hipCheck(hipGetDeviceProperties(&prop, 0));
             double clkMHz = static_cast<double>(getMemoryClockRateKHz()) / 1000.0;
-            double busBytes = static_cast<double>(prop.memoryBusWidth) / 8.0;
+            double busBytes = static_cast<double>(getDeviceAttribute(hipDeviceAttributeMemoryBusWidth)) / 8.0;
             double bytesPerSec = clkMHz * 1e6 * busBytes * 2.0;
             return bytesPerSec / (1024.0 * 1024.0 * 1024.0);
         }();
@@ -247,19 +253,18 @@ namespace util {
     }
 
     /**
+     * @brief Return the total number of compute units on the device.
+     */
+    inline uint32_t getNumberOfComputeUnits() {
+        static uint32_t cus = static_cast<uint32_t>(getDeviceAttribute(hipDeviceAttributeMultiprocessorCount));
+        return cus;
+    }
+
+    /**
      * @brief Compute the number of compute units per die.
      */
     inline uint32_t getComputeUnitsPerDie() {
-        static uint32_t cusPerDie = []() {
-            int device;
-            util::hipCheck(hipGetDevice(&device));
-            int32_t cuCount;
-            util::hipCheck(hipDeviceGetAttribute(
-                &cuCount,
-                hipDeviceAttributeMultiprocessorCount,
-                device));
-            return static_cast<uint32_t>(cuCount) / getNumXCDs();
-        }();
+        static uint32_t cusPerDie = getNumberOfComputeUnits() / getNumXCDs();
         return cusPerDie;
     }
 
@@ -270,10 +275,7 @@ namespace util {
      * getMemoryClockRateKHz(): CUDA 13 removed cudaDeviceProp::clockRate.
      */
     inline uint32_t getClockRateKHz() {
-        int32_t device;
-        util::hipCheck(hipGetDevice(&device));
-        int32_t rateKHz;
-        util::hipCheck(hipDeviceGetAttribute(&rateKHz, hipDeviceAttributeClockRate, device));
+        static uint32_t rateKHz = static_cast<uint32_t>(getDeviceAttribute(hipDeviceAttributeClockRate));
         return rateKHz;
     }
 
@@ -281,13 +283,7 @@ namespace util {
      * @brief Return the native warp/wavefront size of the device.
      */
     inline uint32_t getWarpSize() {
-        static int32_t warpSize = [](){
-            int32_t device;
-            util::hipCheck(hipGetDevice(&device));
-            int32_t v;
-            util::hipCheck(hipDeviceGetAttribute(&v, hipDeviceAttributeWarpSize, device));
-            return v;
-        }();
+        static int32_t warpSize = getDeviceAttribute(hipDeviceAttributeWarpSize);
         return warpSize;
     }
 
@@ -309,59 +305,41 @@ namespace util {
      * @brief Estimate the number of cores per multiprocessor.
      */
     inline uint32_t getNumberOfCoresPerSM() {
-        int device = 0;
-        (void)hipGetDevice(&device);
-        hipDeviceProp_t prop{};
-        if (hipGetDeviceProperties(&prop, device) != hipSuccess) {
-            #ifdef __HIP_PLATFORM_NVIDIA__
-            return 128u;          // safe default for modern NVIDIA (Turing/Ampere/Ada)
-            #else
-            return 64u;           // AMD CUs have 64 FP32 ALUs per CU
+        static uint32_t coresPerSM = []() -> uint32_t {
+            #ifdef __HIP_PLATFORM_AMD__
+            // AMD (GCN/RDNA/CDNA): 64 FP32 ALUs ("stream processors") per CU
+            return 64u;
             #endif
-        }
 
-        #ifdef __HIP_PLATFORM_NVIDIA__
-        const int maj = prop.major;
-        const int min = prop.minor;
+            #ifdef __HIP_PLATFORM_NVIDIA__
+            int device = 0;
+            int maj = 0;
+            int min = 0;
+            // Deliberately not hipCheck'd: an unavailable device falls back to a
+            // default below
+            if (hipGetDevice(&device) != hipSuccess ||
+                hipDeviceGetAttribute(&maj, hipDeviceAttributeComputeCapabilityMajor, device) != hipSuccess ||
+                hipDeviceGetAttribute(&min, hipDeviceAttributeComputeCapabilityMinor, device) != hipSuccess) {
+                return 128u;      // safe default for modern NVIDIA (Turing/Ampere/Ada)
+            }
 
-        // Returns FP32 "CUDA cores" per SM, by compute capability.
-        switch (maj) {
-            case 1:  return 8u;                                 // Tesla
-            case 2:  return (min == 1 ? 48u : 32u);             // Fermi 2.1 vs 2.0
-            case 3:  return 192u;                               // Kepler (SMX)
-            case 5:  return 128u;                               // Maxwell (SMM) 5.0/5.2/5.3
-            case 6:  return (min == 0 ? 64u : 128u);            // Pascal: GP100(6.0)=64, GP10x(6.1/6.2)=128
-            case 7:  return 64u;                                // Volta(7.0/7.2)=64, Turing(7.5)=64
-            case 8:  return (min == 0 ? 64u : 128u);            // Ampere: GA100(8.0)=64, GA10x/Orin/Ada(8.6/8.7/8.9)=128
-            case 9:  return 128u;                               // Hopper (GH100)
-            default: return 128u;                               // reasonable default for unknown future parts
-        }
-        #endif
-        
-        #ifdef __HIP_PLATFORM_AMD__
-        // AMD (GCN/RDNA/CDNA): 64 FP32 ALUs ("stream processors") per CU
-        (void)prop;
-        return 64u;
-        #endif
+            // Returns FP32 "CUDA cores" per SM, by compute capability.
+            switch (maj) {
+                case 1:  return 8u;                             // Tesla
+                case 2:  return (min == 1 ? 48u : 32u);         // Fermi 2.1 vs 2.0
+                case 3:  return 192u;                           // Kepler (SMX)
+                case 5:  return 128u;                           // Maxwell (SMM) 5.0/5.2/5.3
+                case 6:  return (min == 0 ? 64u : 128u);        // Pascal: GP100(6.0)=64, GP10x(6.1/6.2)=128
+                case 7:  return 64u;                            // Volta(7.0/7.2)=64, Turing(7.5)=64
+                case 8:  return (min == 0 ? 64u : 128u);        // Ampere: GA100(8.0)=64, GA10x/Orin/Ada(8.6/8.7/8.9)=128
+                case 9:  return 128u;                           // Hopper (GH100)
+                default: return 128u;                           // reasonable default for unknown future parts
+            }
+            #endif
 
-        return 0u;
-    }
-
-    /**
-     * @brief Return the total number of compute units on the device.
-     */
-    inline uint32_t getNumberOfComputeUnits() {
-        static uint32_t cus = []() {
-            int device;
-            util::hipCheck(hipGetDevice(&device));
-            int32_t cuCount;
-            util::hipCheck(hipDeviceGetAttribute(
-                &cuCount,
-                hipDeviceAttributeMultiprocessorCount,
-                device));
-            return static_cast<uint32_t>(cuCount);
+            return 0u;
         }();
-        return cus;
+        return coresPerSM;
     }
 
 } // namespace util

--- a/src/utils/hip/runtime.hpp
+++ b/src/utils/hip/runtime.hpp
@@ -57,16 +57,7 @@ namespace util {
      * @brief Determine if the device supports cooperative launches.
      */
     inline bool supportsCooperativeLaunch() {
-        static bool supported = []() {
-            int device;
-            util::hipCheck(hipGetDevice(&device));
-            int val = 0;
-            util::hipCheck(hipDeviceGetAttribute(
-                &val,
-                hipDeviceAttributeCooperativeLaunch,
-                device));
-            return val != 0;
-        }();
+        static bool supported = getDeviceAttribute(hipDeviceAttributeCooperativeLaunch) != 0;
         return supported;
     }
 
@@ -116,14 +107,16 @@ namespace util {
      * @brief Maximum number of threads supported per block.
      */
     inline uint32_t getMaxThreadsPerBlock() {
-        static uint32_t maxThreads = [](){
-            int32_t device;
-            util::hipCheck(hipGetDevice(&device));
-            int32_t v;
-            util::hipCheck(hipDeviceGetAttribute(&v, hipDeviceAttributeMaxThreadsPerBlock, device));
-            return v;
-        }();
+        static uint32_t maxThreads = static_cast<uint32_t>(getDeviceAttribute(hipDeviceAttributeMaxThreadsPerBlock));
         return maxThreads;
+    }
+
+    /**
+     * @brief Maximum number of resident blocks per compute unit.
+     */
+    inline uint32_t getMaxBlocksPerMultiProcessor() {
+        static uint32_t maxBlocks = static_cast<uint32_t>(getDeviceAttribute(hipDeviceAttributeMaxBlocksPerMultiProcessor));
+        return maxBlocks;
     }
 
     /**
@@ -131,17 +124,13 @@ namespace util {
      */
     template <typename KernelFunc>
     inline uint32_t getMaxActiveBlocks(KernelFunc kernel, uint32_t blockSize, size_t dynamicSharedMemoryBytes = 0U) {
-        int32_t device;
-        util::hipCheck(hipGetDevice(&device));
-        hipDeviceProp_t prop;
-        util::hipCheck(hipGetDeviceProperties(&prop, device));
         int32_t blocksPerSM = 0;
         util::hipCheck(hipOccupancyMaxActiveBlocksPerMultiprocessor(
             &blocksPerSM,
             kernel,
             static_cast<int>(blockSize),
             dynamicSharedMemoryBytes));
-        return static_cast<uint32_t>(blocksPerSM) * static_cast<uint32_t>(prop.multiProcessorCount);
+        return static_cast<uint32_t>(blocksPerSM) * getNumberOfComputeUnits();
     }
 
     /**
@@ -149,10 +138,7 @@ namespace util {
      */
     inline hipStream_t createStreamForCU(int32_t cuIdx) {
         #ifdef __HIP_PLATFORM_AMD__
-        int32_t dev = 0;
-        util::hipCheck(hipGetDevice(&dev));
-        int32_t numCUs = 0;
-        util::hipCheck(hipDeviceGetAttribute(&numCUs, hipDeviceAttributeMultiprocessorCount, dev));
+        const int32_t numCUs = static_cast<int32_t>(getNumberOfComputeUnits());
         assert(cuIdx >= 0 && cuIdx < numCUs);
         const int32_t len = (numCUs + 31) / 32;
         std::vector<uint32_t> mask(len, 0u);
@@ -175,10 +161,7 @@ namespace util {
      */
     inline hipStream_t createStreamForCUs(const std::vector<uint32_t>& cuIdxs) {
         #ifdef __HIP_PLATFORM_AMD__
-        int32_t dev = 0;
-        util::hipCheck(hipGetDevice(&dev));
-        int32_t numCUs = 0;
-        util::hipCheck(hipDeviceGetAttribute(&numCUs, hipDeviceAttributeMultiprocessorCount, dev));
+        const int32_t numCUs = static_cast<int32_t>(getNumberOfComputeUnits());
         for (int32_t cuIdx : cuIdxs) {
             assert(cuIdx >= 0 && cuIdx < numCUs);
         }


### PR DESCRIPTION
### Enfore Release build type
CMake defines the following compiler flag sets:
No build type: no additional flags
Debug: -g
Release:** -O3 -DNDEBUG

I crossed these three flag sets with the three build types, which results in the following 9 configurations:
Build type x compiler flags = resulting configuration (exact flags), of course -g -g is simply -g
None x no flags = None
Debug x no flags = -g
Release x no flags = -O3 -DNDEBUG
None x -g = -g
Debug x -g = -g -g
Release x -g = -g -O3 -DNDEBUG
None x -03 -DNDEBUG = -O3 -DNDEBUG
Debug x -g = -g -O3 -DNDEBUG
Release x -O3 -DNDEBUG = -O3 -DNDEBUG -O3 -DNDEBUG

I use (Release x no flags = -03 -DNDEBUG) as the BASELINE and compare all other configurations to it. Another important thing to note is that hipcc unconditionally adds -O3 to both the host (CPU) and device (GPU) compilation. So even the no-build-type and Debug configurations produce optimized code. Debug additionally enables debug information.

NVIDIA (narq1 - H00)
Compared to the baseline (Release x no flags), there was no meaningful difference in the other 8 configurations in terms of runtime or MT4G results, just noise. Also, all configurations produced byte-identical GPU device code (this I let AI check).

AMD (milan1 - MI210 CDNA2)
Even here there was no statistically significant difference in runtime or MT4G results. Earlier no-build-type and Debug was failing because the amdclang++ compiler was used, which does not add the -O3 compiler flag, but now hipcc unconditionally adds -O3, so all build types succeed. Here configurations are byte-identical binaries (up to 3.96%, once again I used AI to check this).

=> There is no measurable performance difference between the different build configurations on either NVIDIA or AMD, so we can safely set CMAKE_BUILD_TYPE=Release as the default build type for MT4G.


### Update hipDeviceGetAttribute() implementation
Official NVIDIA documentation
https://docs.nvidia.com/cuda/archive/13.0.0/cuda-toolkit-release-notes/index.html?utm_source=chatgpt.com
`cudaDeviceProp::clockRate` →`cudaDeviceGetAttribute(cudaDevAttrClockRate)`
`cudaDeviceProp::memoryClockRate` →`cudaDeviceGetAttribute(cudaDevAttrMemoryClockRate)`

runtime.hpp
The main change is that `runtime.hpp` was refactored to reuse helper functions from `utils/hip/device.hpp` instead of repeatedly querying HIP device properties directly.
I added one additional function: `getMaxBlocksPerMultiProcessor()`

src/mt4g/benchmarks/bandwidth/*.ccp
I refactored the bandwidth benchmarks’ code to use the new device-property helper APIs introduced in `runtime.hpp` and `device.hpp`, replacing direct access through `getDeviceProperties()`

device.hpp
getDeviceAttribute() takes an attribute as input; asks hip which device is active, e.g. if GPU 0 is selected, `device` becomes `0`. `hipCheck()` wrapper checks whether the HIP call succeeded and handles an error if it didn't.
`hipCheck(hipDevice….)` queries HIP what the value of this particular attribute is for the selected device/GPU; then the value is returned.
⇒ now we can simply do `util::getDeviceAttribute(attributeName)`
⇒ this helper centralizes get current device → query attribute → error check → return value pattern

`getNumberOfCoresPerSM` keeps unchecked queries rather than `util::hipCheck`. It has a deliberate fallback default, so checking would convert graceful degradation into an abort.

getTheoreticalMaxGlobalMemoryBandwidthGiBs()
Before: bus width was hardcoded to GPU 0, while clock rate came from the selected GPU
Now: both are queried from the selected GPU, so `-d N` works correctly for any GPU

`totalGlobalMem` in device.hpp should not be changed to `hipDeviceAttributeTotalGlobalMem`
→ attribute exists in HIP, but not supported on NVIDIA GPUs.
⇒ totalGlobalMem should continue to be obtained through hipGetDeviceProperties()

has.hpp
HSA needs these three PCI values:`pciDomainID`, `pciBusID`, `pciDeviceID`
→ they are already obtained from **one cached device-properties fetch**.
So the code effectively does: Fetch device properties once → keep the result → read the 3 PCI fields from it. That is already efficient because the expensive query happens only once.

main.cpp
→ `util::getDeviceProperties()` (runtime.hpp:67) is a cached static, so the driver is hit once per process: one `hipGetDevice` + one `hipGetDeviceProperties`
→ migrating to getDeviceAttribute() would drastically increase HIP calls: 19 × `getDeviceAttribute()` = 19 `hipGetDevice` + 19 `hipDeviceGetAttribute` = 38 calls and we'd still need the struct fetch for `name`, `totalGlobalMem`, and `asicRevision`. So ~40 calls instead of 2, to produce identical output.
